### PR TITLE
Eliminated caching from all but WorldDataServiceImpl

### DIFF
--- a/src/main/java/com/royware/corona/dashboard/interfaces/ExternalDataService.java
+++ b/src/main/java/com/royware/corona/dashboard/interfaces/ExternalDataService.java
@@ -7,5 +7,4 @@ public interface ExternalDataService {
 	public static final long CACHE_EVICT_PERIOD_MILLISECONDS = 3 * 60 * 60 * 1000;  //every 3 hours
 	public static final String CACHE_NAME = "dataCache";
 	public <T extends CanonicalCases> List<T> makeDataListFromExternalSource(String cacheKey);
-	public void cacheEvict();
 }

--- a/src/main/java/com/royware/corona/dashboard/services/SingleStateDataServiceImpl.java
+++ b/src/main/java/com/royware/corona/dashboard/services/SingleStateDataServiceImpl.java
@@ -1,6 +1,5 @@
 package com.royware.corona.dashboard.services;
 
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -10,10 +9,6 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.cache.annotation.CacheEvict;
-import org.springframework.cache.annotation.Cacheable;
-import org.springframework.scheduling.annotation.EnableScheduling;
-import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.web.client.RestTemplate;
 
 import com.royware.corona.dashboard.DashboardController;
@@ -24,19 +19,15 @@ import com.royware.corona.dashboard.model.UnitedStatesCases;
 /**
  * Provides service methods for getting dashboard data from external sources
  */
-@EnableScheduling
 public class SingleStateDataServiceImpl implements ExternalDataService {
 	@Autowired
 	private RestTemplate restTemplate;
 	
 	private static final Logger log = LoggerFactory.getLogger(DashboardController.class);
-	private String cacheKeyForThisState;
 	
 	@SuppressWarnings("unchecked")
 	@Override
-	@Cacheable(key = "#stateAbbreviation", value = CACHE_NAME)
 	public List<UnitedStatesCases> makeDataListFromExternalSource(String stateAbbreviation) {
-		cacheKeyForThisState = stateAbbreviation;
 		log.info("***** ABOUT TO GET STATE: " + stateAbbreviation + " ****");
 		UnitedStatesCases[] stateDataArray = restTemplate.getForObject(
 				DataUrls.STATE_DATA_URL.toString() + stateAbbreviation.toUpperCase(),
@@ -53,19 +44,5 @@ public class SingleStateDataServiceImpl implements ExternalDataService {
 		log.info("***** FINISHED GETTING STATE: " + stateAbbreviation + " ****");
 		
 		return stateDataList;
-	}
-	
-	@CacheEvict(key = "#cacheKeyForThisState", cacheNames = {CACHE_NAME})
-	@Scheduled(fixedDelay = CACHE_EVICT_PERIOD_MILLISECONDS)
-	@Override
-	public void cacheEvict() {
-		log.info("CACHE FOR STATE " + cacheKeyForThisState + " EVICTED AT: " + LocalDateTime.now());
-		log.info("Repopulating cache...");
-		repopulateCache();
-		log.info("DONE REPOPULATING CACHE FOR " + cacheKeyForThisState + " AT: " + LocalDateTime.now());
-	}
-	
-	private void repopulateCache() {
-		makeDataListFromExternalSource(cacheKeyForThisState);
 	}
 }

--- a/src/main/java/com/royware/corona/dashboard/services/UsDataServiceImpl.java
+++ b/src/main/java/com/royware/corona/dashboard/services/UsDataServiceImpl.java
@@ -1,6 +1,5 @@
 package com.royware.corona.dashboard.services;
 
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -9,26 +8,19 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.cache.annotation.CacheEvict;
-import org.springframework.cache.annotation.Cacheable;
-import org.springframework.scheduling.annotation.EnableScheduling;
-import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 
 import com.royware.corona.dashboard.DashboardController;
-import com.royware.corona.dashboard.enums.CacheKeys;
 import com.royware.corona.dashboard.enums.DataUrls;
 import com.royware.corona.dashboard.interfaces.ExternalDataService;
 import com.royware.corona.dashboard.model.UnitedStatesCases;
 
-@EnableScheduling
 public class UsDataServiceImpl implements ExternalDataService {
 	@Autowired
 	private RestTemplate restTemplate;
 	
 	private static final Logger log = LoggerFactory.getLogger(DashboardController.class);
-	private String cacheKeyToEvict = CacheKeys.CACHE_KEY_US.toString();
 
 	/**
 	 * Gets all US data and returns it as an array of objects
@@ -36,7 +28,6 @@ public class UsDataServiceImpl implements ExternalDataService {
 	 */
 	@SuppressWarnings("unchecked")
 	@Override
-	@Cacheable(key = "#cacheKey", value = CACHE_NAME)
 	public List<UnitedStatesCases> makeDataListFromExternalSource(String cacheKey) {
 		UnitedStatesCases[] usDataArray = null;
 		int tries = 0;
@@ -59,19 +50,5 @@ public class UsDataServiceImpl implements ExternalDataService {
 		
 		log.info("***** FINISHED HITTING ENDPOINT FOR UNITED STATES DATA *****");
 		return usDataList;
-	}
-
-	@CacheEvict(key = "#cacheKeyToEvict", cacheNames = {CACHE_NAME})
-	@Scheduled(fixedDelay = CACHE_EVICT_PERIOD_MILLISECONDS)
-	@Override
-	public void cacheEvict() {
-		log.info("US DATA CACHE WITH KEY " + cacheKeyToEvict + " EVICTED AT: " + LocalDateTime.now());
-		log.info("Repopulating cache...");
-		repopulateCache();
-		log.info("DONE REPOPULATING US CACHE AT: " + LocalDateTime.now());
-	}
-	
-	private void repopulateCache() {
-		makeDataListFromExternalSource(CacheKeys.CACHE_KEY_US.toString());
 	}
 }

--- a/src/main/java/com/royware/corona/dashboard/services/WorldDataServiceImpl.java
+++ b/src/main/java/com/royware/corona/dashboard/services/WorldDataServiceImpl.java
@@ -53,7 +53,6 @@ public class WorldDataServiceImpl implements ExternalDataService {
 
 	@CacheEvict(key = "#cacheKeyToEvict", cacheNames = {CACHE_NAME})
 	@Scheduled(fixedDelay = CACHE_EVICT_PERIOD_MILLISECONDS)
-	@Override
 	public void cacheEvict() {
 		log.info("WORLD DATA CACHE WITH KEY " + cacheKeyToEvict + " EVICTED AT: " + LocalDateTime.now());
 		log.info("Repopulating cache...");


### PR DESCRIPTION
* Was getting cached data conflicts when caching states or the US
excluding New York. Since the US data API is fast, there is no real
advantage to caching it. The world data API is slow, so it's worth
caching it and it works well.