### PR TITLE
Refactor regions data enum

### DIFF
--- a/src/main/java/com/royware/corona/dashboard/config/ApplicationConfig.java
+++ b/src/main/java/com/royware/corona/dashboard/config/ApplicationConfig.java
@@ -22,7 +22,7 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.scheduling.concurrent.ConcurrentTaskScheduler;
 import org.springframework.web.client.RestTemplate;
 
-import com.royware.corona.dashboard.interfaces.data.ExternalDataService;
+import com.royware.corona.dashboard.interfaces.data.IExternalDataConnectionService;
 import com.royware.corona.dashboard.services.data.world.ExternalDataServiceWorldImpl;
 
 @Configuration
@@ -34,7 +34,7 @@ public class ApplicationConfig {
 	@Bean("worldDataService")
 	@Qualifier("world")
     @Scope(ConfigurableBeanFactory.SCOPE_SINGLETON)
-	public ExternalDataService worldDataService() {
+	public IExternalDataConnectionService worldDataService() {
 		return new ExternalDataServiceWorldImpl();
 	}
 	

--- a/src/main/java/com/royware/corona/dashboard/controller/DashboardController.java
+++ b/src/main/java/com/royware/corona/dashboard/controller/DashboardController.java
@@ -18,7 +18,7 @@ import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 import com.royware.corona.dashboard.enums.jsp.JspPageNames;
 import com.royware.corona.dashboard.enums.regions.RegionsData_OLD_DEL_ME;
 import com.royware.corona.dashboard.enums.regions.RegionsInDashboard;
-import com.royware.corona.dashboard.interfaces.dashboard.DashboardConfigService;
+import com.royware.corona.dashboard.interfaces.dashboard.IDashboardConfigService;
 import com.royware.corona.dashboard.model.dashboard.DashboardChart;
 import com.royware.corona.dashboard.services.dashboard.DownloadChartData;
 
@@ -31,7 +31,7 @@ import com.royware.corona.dashboard.services.dashboard.DownloadChartData;
 @Controller
 public class DashboardController {
 	@Autowired
-	private DashboardConfigService dashboardConfigService;
+	private IDashboardConfigService dashboardConfigService;
 	
 	private static final Logger log = LoggerFactory.getLogger(DashboardController.class);
 	private List<DashboardChart> dashboardCharts;

--- a/src/main/java/com/royware/corona/dashboard/controller/DashboardController.java
+++ b/src/main/java/com/royware/corona/dashboard/controller/DashboardController.java
@@ -16,7 +16,8 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 
 import com.royware.corona.dashboard.enums.jsp.JspPageNames;
-import com.royware.corona.dashboard.enums.regions.RegionsData;
+import com.royware.corona.dashboard.enums.regions.RegionsData_OLD_DEL_ME;
+import com.royware.corona.dashboard.enums.regions.RegionsInDashboard;
 import com.royware.corona.dashboard.interfaces.dashboard.DashboardConfigService;
 import com.royware.corona.dashboard.model.dashboard.DashboardChart;
 import com.royware.corona.dashboard.services.dashboard.DownloadChartData;
@@ -44,7 +45,7 @@ public class DashboardController {
 	public String showHomePage(@ModelAttribute("region") String region, ModelMap map) {
 		map.addAttribute("region", region);
 
-		for(RegionsData regionEnum : RegionsData.values()) {
+		for(RegionsInDashboard regionEnum : RegionsInDashboard.values()) {
 			map.addAttribute(regionEnum.name(), regionEnum.name());
 		}
 

--- a/src/main/java/com/royware/corona/dashboard/enums/regions/RegionsData.java
+++ b/src/main/java/com/royware/corona/dashboard/enums/regions/RegionsData.java
@@ -7,12 +7,12 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
 import com.royware.corona.dashboard.enums.data.CacheKeys;
-import com.royware.corona.dashboard.interfaces.data.ExternalDataService;
+import com.royware.corona.dashboard.interfaces.data.IExternalDataConnectionService;
 import com.royware.corona.dashboard.interfaces.model.CanonicalCaseDeathData;
 import com.royware.corona.dashboard.model.data.common.RegionData;
 import com.royware.corona.dashboard.model.data.us.UnitedStatesData;
 import com.royware.corona.dashboard.model.data.world.WorldData;
-//TODO: Refactor this class to a factory pattern instead of an Enum
+
 @Service
 public enum RegionsData {
 	USA {
@@ -22,7 +22,7 @@ public enum RegionsData {
 		}
 		@SuppressWarnings("unchecked")
 		@Override
-		public List<UnitedStatesData> getCoronaVirusDataFromExternalSource(ExternalDataService eds) {
+		public List<UnitedStatesData> getCoronaVirusDataFromExternalSource(IExternalDataConnectionService eds) {
 			Logger log = LoggerFactory.getLogger(RegionsData.class);
 			log.info("In the Regions enum for " + this.name() + " about to call makeDataListFromExternalSource with " + eds.toString());
 			return eds.makeDataListFromExternalSource(CacheKeys.CACHE_KEY_US.getName());
@@ -34,7 +34,7 @@ public enum RegionsData {
 		}
 		@SuppressWarnings("unchecked")
 		@Override
-		public List<WorldData> getCoronaVirusDataFromExternalSource(ExternalDataService eds) {
+		public List<WorldData> getCoronaVirusDataFromExternalSource(IExternalDataConnectionService eds) {
 			Logger log = LoggerFactory.getLogger(RegionsData.class);
 			log.info("In the Regions enum for " + this.name() + " about to call makeDataListFromExternalSource with " + eds.toString());
 			return eds.makeDataListFromExternalSource(this.name());
@@ -46,7 +46,7 @@ public enum RegionsData {
 		}
 		@SuppressWarnings("unchecked")
 		@Override
-		public List<WorldData> getCoronaVirusDataFromExternalSource(ExternalDataService eds) {
+		public List<WorldData> getCoronaVirusDataFromExternalSource(IExternalDataConnectionService eds) {
 			Logger log = LoggerFactory.getLogger(RegionsData.class);
 			log.info("In the Regions enum for " + this.name() + " about to call makeDataListFromExternalSource with " + eds.toString());
 			return eds.makeDataListFromExternalSource(this.name());
@@ -58,7 +58,7 @@ public enum RegionsData {
 		}
 		@SuppressWarnings("unchecked")
 		@Override
-		public List<WorldData> getCoronaVirusDataFromExternalSource(ExternalDataService eds) {
+		public List<WorldData> getCoronaVirusDataFromExternalSource(IExternalDataConnectionService eds) {
 			Logger log = LoggerFactory.getLogger(RegionsData.class);
 			log.info("In the Regions enum for " + this.name() + " about to call makeDataListFromExternalSource with " + eds.toString());
 			return eds.makeDataListFromExternalSource(this.name());
@@ -70,7 +70,7 @@ public enum RegionsData {
 		}
 		@SuppressWarnings("unchecked")
 		@Override
-		public List<WorldData> getCoronaVirusDataFromExternalSource(ExternalDataService eds) {
+		public List<WorldData> getCoronaVirusDataFromExternalSource(IExternalDataConnectionService eds) {
 			Logger log = LoggerFactory.getLogger(RegionsData.class);
 			log.info("In the Regions enum for " + this.name() + " about to call makeDataListFromExternalSource with " + eds.toString());
 			return eds.makeDataListFromExternalSource(this.name());
@@ -82,7 +82,7 @@ public enum RegionsData {
 		}
 		@SuppressWarnings("unchecked")
 		@Override
-		public List<WorldData> getCoronaVirusDataFromExternalSource(ExternalDataService eds) {
+		public List<WorldData> getCoronaVirusDataFromExternalSource(IExternalDataConnectionService eds) {
 			Logger log = LoggerFactory.getLogger(RegionsData.class);
 			log.info("In the Regions enum for " + this.name() + " about to call makeDataListFromExternalSource with " + eds.toString());
 			return eds.makeDataListFromExternalSource(this.name());
@@ -94,7 +94,7 @@ public enum RegionsData {
 		}
 		@SuppressWarnings("unchecked")
 		@Override
-		public List<WorldData> getCoronaVirusDataFromExternalSource(ExternalDataService eds) {
+		public List<WorldData> getCoronaVirusDataFromExternalSource(IExternalDataConnectionService eds) {
 			Logger log = LoggerFactory.getLogger(RegionsData.class);
 			log.info("In the Regions enum for " + this.name() + " about to call makeDataListFromExternalSource with " + eds.toString());
 			return eds.makeDataListFromExternalSource(this.name());
@@ -106,7 +106,7 @@ public enum RegionsData {
 		}
 		@SuppressWarnings("unchecked")
 		@Override
-		public List<WorldData> getCoronaVirusDataFromExternalSource(ExternalDataService eds) {
+		public List<WorldData> getCoronaVirusDataFromExternalSource(IExternalDataConnectionService eds) {
 			Logger log = LoggerFactory.getLogger(RegionsData.class);
 			log.info("In the Regions enum for " + this.name() + " about to call makeDataListFromExternalSource with " + eds.toString());
 			return eds.makeDataListFromExternalSource(this.name());
@@ -118,7 +118,7 @@ public enum RegionsData {
 		}
 		@SuppressWarnings("unchecked")
 		@Override
-		public List<WorldData> getCoronaVirusDataFromExternalSource(ExternalDataService eds) {
+		public List<WorldData> getCoronaVirusDataFromExternalSource(IExternalDataConnectionService eds) {
 			Logger log = LoggerFactory.getLogger(RegionsData.class);
 			log.info("In the Regions enum for " + this.name() + " about to call makeDataListFromExternalSource with " + eds.toString());
 			return eds.makeDataListFromExternalSource(this.name());
@@ -130,7 +130,7 @@ public enum RegionsData {
 		}
 		@SuppressWarnings("unchecked")
 		@Override
-		public List<WorldData> getCoronaVirusDataFromExternalSource(ExternalDataService eds) {
+		public List<WorldData> getCoronaVirusDataFromExternalSource(IExternalDataConnectionService eds) {
 			Logger log = LoggerFactory.getLogger(RegionsData.class);
 			log.info("In the Regions enum for " + this.name() + " about to call makeDataListFromExternalSource with " + eds.toString());
 			return eds.makeDataListFromExternalSource(this.name());
@@ -142,7 +142,7 @@ public enum RegionsData {
 		}
 		@SuppressWarnings("unchecked")
 		@Override
-		public List<WorldData> getCoronaVirusDataFromExternalSource(ExternalDataService eds) {
+		public List<WorldData> getCoronaVirusDataFromExternalSource(IExternalDataConnectionService eds) {
 			Logger log = LoggerFactory.getLogger(RegionsData.class);
 			log.info("In the Regions enum for " + this.name() + " about to call makeDataListFromExternalSource with " + eds.toString());
 			return eds.makeDataListFromExternalSource(this.name());
@@ -154,7 +154,7 @@ public enum RegionsData {
 		}
 		@SuppressWarnings("unchecked")
 		@Override
-		public List<WorldData> getCoronaVirusDataFromExternalSource(ExternalDataService eds) {
+		public List<WorldData> getCoronaVirusDataFromExternalSource(IExternalDataConnectionService eds) {
 			Logger log = LoggerFactory.getLogger(RegionsData.class);
 			log.info("In the Regions enum for " + this.name() + " about to call makeDataListFromExternalSource with " + eds.toString());
 			return eds.makeDataListFromExternalSource(this.name());
@@ -166,7 +166,7 @@ public enum RegionsData {
 		}
 		@SuppressWarnings("unchecked")
 		@Override
-		public List<WorldData> getCoronaVirusDataFromExternalSource(ExternalDataService eds) {
+		public List<WorldData> getCoronaVirusDataFromExternalSource(IExternalDataConnectionService eds) {
 			Logger log = LoggerFactory.getLogger(RegionsData.class);
 			log.info("In the Regions enum for " + this.name() + " about to call makeDataListFromExternalSource with " + eds.toString());
 			return eds.makeDataListFromExternalSource(this.name());
@@ -178,7 +178,7 @@ public enum RegionsData {
 		}
 		@SuppressWarnings("unchecked")
 		@Override
-		public List<WorldData> getCoronaVirusDataFromExternalSource(ExternalDataService eds) {
+		public List<WorldData> getCoronaVirusDataFromExternalSource(IExternalDataConnectionService eds) {
 			Logger log = LoggerFactory.getLogger(RegionsData.class);
 			log.info("In the Regions enum for " + this.name() + " about to call makeDataListFromExternalSource with " + eds.toString());
 			return eds.makeDataListFromExternalSource(this.name());
@@ -190,7 +190,7 @@ public enum RegionsData {
 		}
 		@SuppressWarnings("unchecked")
 		@Override
-		public List<WorldData> getCoronaVirusDataFromExternalSource(ExternalDataService eds) {
+		public List<WorldData> getCoronaVirusDataFromExternalSource(IExternalDataConnectionService eds) {
 			Logger log = LoggerFactory.getLogger(RegionsData.class);
 			log.info("In the Regions enum for " + this.name() + " about to call makeDataListFromExternalSource with " + eds.toString());
 			return eds.makeDataListFromExternalSource(this.name());
@@ -202,7 +202,7 @@ public enum RegionsData {
 		}
 		@SuppressWarnings("unchecked")
 		@Override
-		public List<WorldData> getCoronaVirusDataFromExternalSource(ExternalDataService eds) {
+		public List<WorldData> getCoronaVirusDataFromExternalSource(IExternalDataConnectionService eds) {
 			Logger log = LoggerFactory.getLogger(RegionsData.class);
 			log.info("In the Regions enum for " + this.name() + " about to call makeDataListFromExternalSource with " + eds.toString());
 			return eds.makeDataListFromExternalSource(this.name());
@@ -214,7 +214,7 @@ public enum RegionsData {
 		}
 		@SuppressWarnings("unchecked")
 		@Override
-		public List<WorldData> getCoronaVirusDataFromExternalSource(ExternalDataService eds) {
+		public List<WorldData> getCoronaVirusDataFromExternalSource(IExternalDataConnectionService eds) {
 			Logger log = LoggerFactory.getLogger(RegionsData.class);
 			log.info("In the Regions enum for " + this.name() + " about to call makeDataListFromExternalSource with " + eds.toString());
 			return eds.makeDataListFromExternalSource(this.name());
@@ -227,7 +227,7 @@ public enum RegionsData {
 		}
 		@SuppressWarnings("unchecked")
 		@Override
-		public List<UnitedStatesData> getCoronaVirusDataFromExternalSource(ExternalDataService eds) {
+		public List<UnitedStatesData> getCoronaVirusDataFromExternalSource(IExternalDataConnectionService eds) {
 			Logger log = LoggerFactory.getLogger(RegionsData.class);
 			log.info("In the Regions enum for " + this.name() + " about to call makeDataListFromExternalSource with " + eds.toString());
 			return eds.makeDataListFromExternalSource("NY");
@@ -239,7 +239,7 @@ public enum RegionsData {
 		}
 		@SuppressWarnings("unchecked")
 		@Override
-		public List<UnitedStatesData> getCoronaVirusDataFromExternalSource(ExternalDataService eds) {
+		public List<UnitedStatesData> getCoronaVirusDataFromExternalSource(IExternalDataConnectionService eds) {
 			Logger log = LoggerFactory.getLogger(RegionsData.class);
 			log.info("In the Regions enum for " + this.name() + " about to call makeDataListFromExternalSource with " + eds.toString());
 			return eds.makeDataListFromExternalSource(this.name());
@@ -251,7 +251,7 @@ public enum RegionsData {
 		}
 		@SuppressWarnings("unchecked")
 		@Override
-		public List<UnitedStatesData> getCoronaVirusDataFromExternalSource(ExternalDataService eds) {
+		public List<UnitedStatesData> getCoronaVirusDataFromExternalSource(IExternalDataConnectionService eds) {
 			Logger log = LoggerFactory.getLogger(RegionsData.class);
 			log.info("In the Regions enum for " + this.name() + " about to call makeDataListFromExternalSource with " + eds.toString());
 			return eds.makeDataListFromExternalSource(this.name());
@@ -263,7 +263,7 @@ public enum RegionsData {
 		}
 		@SuppressWarnings("unchecked")
 		@Override
-		public List<UnitedStatesData> getCoronaVirusDataFromExternalSource(ExternalDataService eds) {
+		public List<UnitedStatesData> getCoronaVirusDataFromExternalSource(IExternalDataConnectionService eds) {
 			Logger log = LoggerFactory.getLogger(RegionsData.class);
 			log.info("In the Regions enum for " + this.name() + " about to call makeDataListFromExternalSource with " + eds.toString());
 			return eds.makeDataListFromExternalSource(this.name());
@@ -275,7 +275,7 @@ public enum RegionsData {
 		}
 		@SuppressWarnings("unchecked")
 		@Override
-		public List<UnitedStatesData> getCoronaVirusDataFromExternalSource(ExternalDataService eds) {
+		public List<UnitedStatesData> getCoronaVirusDataFromExternalSource(IExternalDataConnectionService eds) {
 			Logger log = LoggerFactory.getLogger(RegionsData.class);
 			log.info("In the Regions enum for " + this.name() + " about to call makeDataListFromExternalSource with " + eds.toString());
 			return eds.makeDataListFromExternalSource(this.name());
@@ -287,7 +287,7 @@ public enum RegionsData {
 		}
 		@SuppressWarnings("unchecked")
 		@Override
-		public List<UnitedStatesData> getCoronaVirusDataFromExternalSource(ExternalDataService eds) {
+		public List<UnitedStatesData> getCoronaVirusDataFromExternalSource(IExternalDataConnectionService eds) {
 			Logger log = LoggerFactory.getLogger(RegionsData.class);
 			log.info("In the Regions enum for " + this.name() + " about to call makeDataListFromExternalSource with " + eds.toString());
 			return eds.makeDataListFromExternalSource(this.name());
@@ -299,7 +299,7 @@ public enum RegionsData {
 		}
 		@SuppressWarnings("unchecked")
 		@Override
-		public List<UnitedStatesData> getCoronaVirusDataFromExternalSource(ExternalDataService eds) {
+		public List<UnitedStatesData> getCoronaVirusDataFromExternalSource(IExternalDataConnectionService eds) {
 			Logger log = LoggerFactory.getLogger(RegionsData.class);
 			log.info("In the Regions enum for " + this.name() + " about to call makeDataListFromExternalSource with " + eds.toString());
 			return eds.makeDataListFromExternalSource(this.name());
@@ -311,7 +311,7 @@ public enum RegionsData {
 		}
 		@SuppressWarnings("unchecked")
 		@Override
-		public List<UnitedStatesData> getCoronaVirusDataFromExternalSource(ExternalDataService eds) {
+		public List<UnitedStatesData> getCoronaVirusDataFromExternalSource(IExternalDataConnectionService eds) {
 			Logger log = LoggerFactory.getLogger(RegionsData.class);
 			log.info("In the Regions enum for " + this.name() + " about to call makeDataListFromExternalSource with " + eds.toString());
 			return eds.makeDataListFromExternalSource(this.name());
@@ -323,7 +323,7 @@ public enum RegionsData {
 		}
 		@SuppressWarnings("unchecked")
 		@Override
-		public List<UnitedStatesData> getCoronaVirusDataFromExternalSource(ExternalDataService eds) {
+		public List<UnitedStatesData> getCoronaVirusDataFromExternalSource(IExternalDataConnectionService eds) {
 			Logger log = LoggerFactory.getLogger(RegionsData.class);
 			log.info("In the Regions enum for " + this.name() + " about to call makeDataListFromExternalSource with " + eds.toString());
 			return eds.makeDataListFromExternalSource(this.name());
@@ -335,7 +335,7 @@ public enum RegionsData {
 		}
 		@SuppressWarnings("unchecked")
 		@Override
-		public List<UnitedStatesData> getCoronaVirusDataFromExternalSource(ExternalDataService eds) {
+		public List<UnitedStatesData> getCoronaVirusDataFromExternalSource(IExternalDataConnectionService eds) {
 			Logger log = LoggerFactory.getLogger(RegionsData.class);
 			log.info("In the Regions enum for " + this.name() + " about to call makeDataListFromExternalSource with " + eds.toString());
 			return eds.makeDataListFromExternalSource(this.name());
@@ -347,7 +347,7 @@ public enum RegionsData {
 		}
 		@SuppressWarnings("unchecked")
 		@Override
-		public List<UnitedStatesData> getCoronaVirusDataFromExternalSource(ExternalDataService eds) {
+		public List<UnitedStatesData> getCoronaVirusDataFromExternalSource(IExternalDataConnectionService eds) {
 			Logger log = LoggerFactory.getLogger(RegionsData.class);
 			log.info("In the Regions enum for " + this.name() + " about to call makeDataListFromExternalSource with " + eds.toString());
 			return eds.makeDataListFromExternalSource(this.name());
@@ -359,7 +359,7 @@ public enum RegionsData {
 		}
 		@SuppressWarnings("unchecked")
 		@Override
-		public List<UnitedStatesData> getCoronaVirusDataFromExternalSource(ExternalDataService eds) {
+		public List<UnitedStatesData> getCoronaVirusDataFromExternalSource(IExternalDataConnectionService eds) {
 			Logger log = LoggerFactory.getLogger(RegionsData.class);
 			log.info("In the Regions enum for " + this.name() + " about to call makeDataListFromExternalSource with " + eds.toString());
 			return eds.makeDataListFromExternalSource(this.name());
@@ -371,7 +371,7 @@ public enum RegionsData {
 		}
 		@SuppressWarnings("unchecked")
 		@Override
-		public List<UnitedStatesData> getCoronaVirusDataFromExternalSource(ExternalDataService eds) {
+		public List<UnitedStatesData> getCoronaVirusDataFromExternalSource(IExternalDataConnectionService eds) {
 			Logger log = LoggerFactory.getLogger(RegionsData.class);
 			log.info("In the Regions enum for " + this.name() + " about to call makeDataListFromExternalSource with " + eds.toString());
 			return eds.makeDataListFromExternalSource(this.name());
@@ -383,7 +383,7 @@ public enum RegionsData {
 		}
 		@SuppressWarnings("unchecked")
 		@Override
-		public List<UnitedStatesData> getCoronaVirusDataFromExternalSource(ExternalDataService eds) {
+		public List<UnitedStatesData> getCoronaVirusDataFromExternalSource(IExternalDataConnectionService eds) {
 			Logger log = LoggerFactory.getLogger(RegionsData.class);
 			log.info("In the Regions enum for " + this.name() + " about to call makeDataListFromExternalSource with " + eds.toString());
 			return eds.makeDataListFromExternalSource(this.name());
@@ -395,7 +395,7 @@ public enum RegionsData {
 		}
 		@SuppressWarnings("unchecked")
 		@Override
-		public List<UnitedStatesData> getCoronaVirusDataFromExternalSource(ExternalDataService eds) {
+		public List<UnitedStatesData> getCoronaVirusDataFromExternalSource(IExternalDataConnectionService eds) {
 			Logger log = LoggerFactory.getLogger(RegionsData.class);
 			log.info("In the Regions enum for " + this.name() + " about to call makeDataListFromExternalSource with " + eds.toString());
 			return eds.makeDataListFromExternalSource(this.name());
@@ -407,7 +407,7 @@ public enum RegionsData {
 		}
 		@SuppressWarnings("unchecked")
 		@Override
-		public List<UnitedStatesData> getCoronaVirusDataFromExternalSource(ExternalDataService eds) {
+		public List<UnitedStatesData> getCoronaVirusDataFromExternalSource(IExternalDataConnectionService eds) {
 			Logger log = LoggerFactory.getLogger(RegionsData.class);
 			log.info("In the Regions enum for " + this.name() + " about to call makeDataListFromExternalSource with " + eds.toString());
 			return eds.makeDataListFromExternalSource(this.name());
@@ -419,7 +419,7 @@ public enum RegionsData {
 		}
 		@SuppressWarnings("unchecked")
 		@Override
-		public List<UnitedStatesData> getCoronaVirusDataFromExternalSource(ExternalDataService eds) {
+		public List<UnitedStatesData> getCoronaVirusDataFromExternalSource(IExternalDataConnectionService eds) {
 			Logger log = LoggerFactory.getLogger(RegionsData.class);
 			log.info("In the Regions enum for " + this.name() + " about to call makeDataListFromExternalSource with " + eds.toString());
 			return eds.makeDataListFromExternalSource(this.name());
@@ -431,7 +431,7 @@ public enum RegionsData {
 		}
 		@SuppressWarnings("unchecked")
 		@Override
-		public List<UnitedStatesData> getCoronaVirusDataFromExternalSource(ExternalDataService eds) {
+		public List<UnitedStatesData> getCoronaVirusDataFromExternalSource(IExternalDataConnectionService eds) {
 			Logger log = LoggerFactory.getLogger(RegionsData.class);
 			log.info("In the Regions enum for " + this.name() + " about to call makeDataListFromExternalSource with " + eds.toString());
 			return eds.makeDataListFromExternalSource(this.name());
@@ -443,7 +443,7 @@ public enum RegionsData {
 		}
 		@SuppressWarnings("unchecked")
 		@Override
-		public List<UnitedStatesData> getCoronaVirusDataFromExternalSource(ExternalDataService eds) {
+		public List<UnitedStatesData> getCoronaVirusDataFromExternalSource(IExternalDataConnectionService eds) {
 			Logger log = LoggerFactory.getLogger(RegionsData.class);
 			log.info("In the Regions enum for " + this.name() + " about to call makeDataListFromExternalSource with " + eds.toString());
 			return eds.makeDataListFromExternalSource(this.name());
@@ -455,7 +455,7 @@ public enum RegionsData {
 		}
 		@SuppressWarnings("unchecked")
 		@Override
-		public List<UnitedStatesData> getCoronaVirusDataFromExternalSource(ExternalDataService eds) {
+		public List<UnitedStatesData> getCoronaVirusDataFromExternalSource(IExternalDataConnectionService eds) {
 			Logger log = LoggerFactory.getLogger(RegionsData.class);
 			log.info("In the Regions enum for " + this.name() + " about to call makeDataListFromExternalSource with " + eds.toString());
 			return eds.makeDataListFromExternalSource(this.name());
@@ -467,7 +467,7 @@ public enum RegionsData {
 		}
 		@SuppressWarnings("unchecked")
 		@Override
-		public List<UnitedStatesData> getCoronaVirusDataFromExternalSource(ExternalDataService eds) {
+		public List<UnitedStatesData> getCoronaVirusDataFromExternalSource(IExternalDataConnectionService eds) {
 			Logger log = LoggerFactory.getLogger(RegionsData.class);
 			log.info("In the Regions enum for " + this.name() + " about to call makeDataListFromExternalSource with " + eds.toString());
 			return eds.makeDataListFromExternalSource(this.name());
@@ -479,7 +479,7 @@ public enum RegionsData {
 		}
 		@SuppressWarnings("unchecked")
 		@Override
-		public List<UnitedStatesData> getCoronaVirusDataFromExternalSource(ExternalDataService eds) {
+		public List<UnitedStatesData> getCoronaVirusDataFromExternalSource(IExternalDataConnectionService eds) {
 			Logger log = LoggerFactory.getLogger(RegionsData.class);
 			log.info("In the Regions enum for " + this.name() + " about to call makeDataListFromExternalSource with " + eds.toString());
 			return eds.makeDataListFromExternalSource(this.name());
@@ -491,7 +491,7 @@ public enum RegionsData {
 		}
 		@SuppressWarnings("unchecked")
 		@Override
-		public List<UnitedStatesData> getCoronaVirusDataFromExternalSource(ExternalDataService eds) {
+		public List<UnitedStatesData> getCoronaVirusDataFromExternalSource(IExternalDataConnectionService eds) {
 			Logger log = LoggerFactory.getLogger(RegionsData.class);
 			log.info("In the Regions enum for " + this.name() + " about to call makeDataListFromExternalSource with " + eds.toString());
 			return eds.makeDataListFromExternalSource(this.name());
@@ -503,7 +503,7 @@ public enum RegionsData {
 		}
 		@SuppressWarnings("unchecked")
 		@Override
-		public List<UnitedStatesData> getCoronaVirusDataFromExternalSource(ExternalDataService eds) {
+		public List<UnitedStatesData> getCoronaVirusDataFromExternalSource(IExternalDataConnectionService eds) {
 			Logger log = LoggerFactory.getLogger(RegionsData.class);
 			log.info("In the Regions enum for " + this.name() + " about to call makeDataListFromExternalSource with " + eds.toString());
 			return eds.makeDataListFromExternalSource(this.name());
@@ -515,7 +515,7 @@ public enum RegionsData {
 		}
 		@SuppressWarnings("unchecked")
 		@Override
-		public List<UnitedStatesData> getCoronaVirusDataFromExternalSource(ExternalDataService eds) {
+		public List<UnitedStatesData> getCoronaVirusDataFromExternalSource(IExternalDataConnectionService eds) {
 			Logger log = LoggerFactory.getLogger(RegionsData.class);
 			log.info("In the Regions enum for " + this.name() + " about to call makeDataListFromExternalSource with " + eds.toString());
 			return eds.makeDataListFromExternalSource(this.name());
@@ -527,7 +527,7 @@ public enum RegionsData {
 		}
 		@SuppressWarnings("unchecked")
 		@Override
-		public List<UnitedStatesData> getCoronaVirusDataFromExternalSource(ExternalDataService eds) {
+		public List<UnitedStatesData> getCoronaVirusDataFromExternalSource(IExternalDataConnectionService eds) {
 			Logger log = LoggerFactory.getLogger(RegionsData.class);
 			log.info("In the Regions enum for " + this.name() + " about to call makeDataListFromExternalSource with " + eds.toString());
 			return eds.makeDataListFromExternalSource(this.name());
@@ -539,7 +539,7 @@ public enum RegionsData {
 		}
 		@SuppressWarnings("unchecked")
 		@Override
-		public List<UnitedStatesData> getCoronaVirusDataFromExternalSource(ExternalDataService eds) {
+		public List<UnitedStatesData> getCoronaVirusDataFromExternalSource(IExternalDataConnectionService eds) {
 			Logger log = LoggerFactory.getLogger(RegionsData.class);
 			log.info("In the Regions enum for " + this.name() + " about to call makeDataListFromExternalSource with " + eds.toString());
 			return eds.makeDataListFromExternalSource(this.name());
@@ -551,7 +551,7 @@ public enum RegionsData {
 		}
 		@SuppressWarnings("unchecked")
 		@Override
-		public List<UnitedStatesData> getCoronaVirusDataFromExternalSource(ExternalDataService eds) {
+		public List<UnitedStatesData> getCoronaVirusDataFromExternalSource(IExternalDataConnectionService eds) {
 			Logger log = LoggerFactory.getLogger(RegionsData.class);
 			log.info("In the Regions enum for " + this.name() + " about to call makeDataListFromExternalSource with " + eds.toString());
 			return eds.makeDataListFromExternalSource(this.name());
@@ -563,7 +563,7 @@ public enum RegionsData {
 		}
 		@SuppressWarnings("unchecked")
 		@Override
-		public List<UnitedStatesData> getCoronaVirusDataFromExternalSource(ExternalDataService eds) {
+		public List<UnitedStatesData> getCoronaVirusDataFromExternalSource(IExternalDataConnectionService eds) {
 			Logger log = LoggerFactory.getLogger(RegionsData.class);
 			log.info("In the Regions enum for " + this.name() + " about to call makeDataListFromExternalSource with " + eds.toString());
 			return eds.makeDataListFromExternalSource(this.name());
@@ -575,7 +575,7 @@ public enum RegionsData {
 		}
 		@SuppressWarnings("unchecked")
 		@Override
-		public List<UnitedStatesData> getCoronaVirusDataFromExternalSource(ExternalDataService eds) {
+		public List<UnitedStatesData> getCoronaVirusDataFromExternalSource(IExternalDataConnectionService eds) {
 			Logger log = LoggerFactory.getLogger(RegionsData.class);
 			log.info("In the Regions enum for " + this.name() + " about to call makeDataListFromExternalSource with " + eds.toString());
 			return eds.makeDataListFromExternalSource(this.name());
@@ -587,7 +587,7 @@ public enum RegionsData {
 		}
 		@SuppressWarnings("unchecked")
 		@Override
-		public List<UnitedStatesData> getCoronaVirusDataFromExternalSource(ExternalDataService eds) {
+		public List<UnitedStatesData> getCoronaVirusDataFromExternalSource(IExternalDataConnectionService eds) {
 			Logger log = LoggerFactory.getLogger(RegionsData.class);
 			log.info("In the Regions enum for " + this.name() + " about to call makeDataListFromExternalSource with " + eds.toString());
 			return eds.makeDataListFromExternalSource(this.name());
@@ -599,7 +599,7 @@ public enum RegionsData {
 		}
 		@SuppressWarnings("unchecked")
 		@Override
-		public List<UnitedStatesData> getCoronaVirusDataFromExternalSource(ExternalDataService eds) {
+		public List<UnitedStatesData> getCoronaVirusDataFromExternalSource(IExternalDataConnectionService eds) {
 			Logger log = LoggerFactory.getLogger(RegionsData.class);
 			log.info("In the Regions enum for " + this.name() + " about to call makeDataListFromExternalSource with " + eds.toString());
 			return eds.makeDataListFromExternalSource(this.name());
@@ -611,7 +611,7 @@ public enum RegionsData {
 		}
 		@SuppressWarnings("unchecked")
 		@Override
-		public List<UnitedStatesData> getCoronaVirusDataFromExternalSource(ExternalDataService eds) {
+		public List<UnitedStatesData> getCoronaVirusDataFromExternalSource(IExternalDataConnectionService eds) {
 			Logger log = LoggerFactory.getLogger(RegionsData.class);
 			log.info("In the Regions enum for " + this.name() + " about to call makeDataListFromExternalSource with " + eds.toString());
 			return eds.makeDataListFromExternalSource(this.name());
@@ -623,7 +623,7 @@ public enum RegionsData {
 		}
 		@SuppressWarnings("unchecked")
 		@Override
-		public List<UnitedStatesData> getCoronaVirusDataFromExternalSource(ExternalDataService eds) {
+		public List<UnitedStatesData> getCoronaVirusDataFromExternalSource(IExternalDataConnectionService eds) {
 			Logger log = LoggerFactory.getLogger(RegionsData.class);
 			log.info("In the Regions enum for " + this.name() + " about to call makeDataListFromExternalSource with " + eds.toString());
 			return eds.makeDataListFromExternalSource(this.name());
@@ -635,7 +635,7 @@ public enum RegionsData {
 		}
 		@SuppressWarnings("unchecked")
 		@Override
-		public List<UnitedStatesData> getCoronaVirusDataFromExternalSource(ExternalDataService eds) {
+		public List<UnitedStatesData> getCoronaVirusDataFromExternalSource(IExternalDataConnectionService eds) {
 			Logger log = LoggerFactory.getLogger(RegionsData.class);
 			log.info("In the Regions enum for " + this.name() + " about to call makeDataListFromExternalSource with " + eds.toString());
 			return eds.makeDataListFromExternalSource(this.name());
@@ -647,7 +647,7 @@ public enum RegionsData {
 		}
 		@SuppressWarnings("unchecked")
 		@Override
-		public List<UnitedStatesData> getCoronaVirusDataFromExternalSource(ExternalDataService eds) {
+		public List<UnitedStatesData> getCoronaVirusDataFromExternalSource(IExternalDataConnectionService eds) {
 			Logger log = LoggerFactory.getLogger(RegionsData.class);
 			log.info("In the Regions enum for " + this.name() + " about to call makeDataListFromExternalSource with " + eds.toString());
 			return eds.makeDataListFromExternalSource(this.name());
@@ -659,7 +659,7 @@ public enum RegionsData {
 		}
 		@SuppressWarnings("unchecked")
 		@Override
-		public List<UnitedStatesData> getCoronaVirusDataFromExternalSource(ExternalDataService eds) {
+		public List<UnitedStatesData> getCoronaVirusDataFromExternalSource(IExternalDataConnectionService eds) {
 			Logger log = LoggerFactory.getLogger(RegionsData.class);
 			log.info("In the Regions enum for " + this.name() + " about to call makeDataListFromExternalSource with " + eds.toString());
 			return eds.makeDataListFromExternalSource(this.name());
@@ -671,7 +671,7 @@ public enum RegionsData {
 		}
 		@SuppressWarnings("unchecked")
 		@Override
-		public List<UnitedStatesData> getCoronaVirusDataFromExternalSource(ExternalDataService eds) {
+		public List<UnitedStatesData> getCoronaVirusDataFromExternalSource(IExternalDataConnectionService eds) {
 			Logger log = LoggerFactory.getLogger(RegionsData.class);
 			log.info("In the Regions enum for " + this.name() + " about to call makeDataListFromExternalSource with " + eds.toString());
 			return eds.makeDataListFromExternalSource(this.name());
@@ -683,7 +683,7 @@ public enum RegionsData {
 		}
 		@SuppressWarnings("unchecked")
 		@Override
-		public List<UnitedStatesData> getCoronaVirusDataFromExternalSource(ExternalDataService eds) {
+		public List<UnitedStatesData> getCoronaVirusDataFromExternalSource(IExternalDataConnectionService eds) {
 			Logger log = LoggerFactory.getLogger(RegionsData.class);
 			log.info("In the Regions enum for " + this.name() + " about to call makeDataListFromExternalSource with " + eds.toString());
 			return eds.makeDataListFromExternalSource(this.name());
@@ -695,7 +695,7 @@ public enum RegionsData {
 		}
 		@SuppressWarnings("unchecked")
 		@Override
-		public List<UnitedStatesData> getCoronaVirusDataFromExternalSource(ExternalDataService eds) {
+		public List<UnitedStatesData> getCoronaVirusDataFromExternalSource(IExternalDataConnectionService eds) {
 			Logger log = LoggerFactory.getLogger(RegionsData.class);
 			log.info("In the Regions enum for " + this.name() + " about to call makeDataListFromExternalSource with " + eds.toString());
 			return eds.makeDataListFromExternalSource(this.name());
@@ -707,7 +707,7 @@ public enum RegionsData {
 		}
 		@SuppressWarnings("unchecked")
 		@Override
-		public List<UnitedStatesData> getCoronaVirusDataFromExternalSource(ExternalDataService eds) {
+		public List<UnitedStatesData> getCoronaVirusDataFromExternalSource(IExternalDataConnectionService eds) {
 			Logger log = LoggerFactory.getLogger(RegionsData.class);
 			log.info("In the Regions enum for " + this.name() + " about to call makeDataListFromExternalSource with " + eds.toString());
 			return eds.makeDataListFromExternalSource(this.name());
@@ -719,7 +719,7 @@ public enum RegionsData {
 		}
 		@SuppressWarnings("unchecked")
 		@Override
-		public List<UnitedStatesData> getCoronaVirusDataFromExternalSource(ExternalDataService eds) {
+		public List<UnitedStatesData> getCoronaVirusDataFromExternalSource(IExternalDataConnectionService eds) {
 			Logger log = LoggerFactory.getLogger(RegionsData.class);
 			log.info("In the Regions enum for " + this.name() + " about to call makeDataListFromExternalSource with " + eds.toString());
 			return eds.makeDataListFromExternalSource(this.name());
@@ -731,7 +731,7 @@ public enum RegionsData {
 		}
 		@SuppressWarnings("unchecked")
 		@Override
-		public List<UnitedStatesData> getCoronaVirusDataFromExternalSource(ExternalDataService eds) {
+		public List<UnitedStatesData> getCoronaVirusDataFromExternalSource(IExternalDataConnectionService eds) {
 			Logger log = LoggerFactory.getLogger(RegionsData.class);
 			log.info("In the Regions enum for " + this.name() + " about to call makeDataListFromExternalSource with " + eds.toString());
 			return eds.makeDataListFromExternalSource(this.name());
@@ -743,7 +743,7 @@ public enum RegionsData {
 		}
 		@SuppressWarnings("unchecked")
 		@Override
-		public List<UnitedStatesData> getCoronaVirusDataFromExternalSource(ExternalDataService eds) {
+		public List<UnitedStatesData> getCoronaVirusDataFromExternalSource(IExternalDataConnectionService eds) {
 			Logger log = LoggerFactory.getLogger(RegionsData.class);
 			log.info("In the Regions enum for " + this.name() + " about to call makeDataListFromExternalSource with " + eds.toString());
 			return eds.makeDataListFromExternalSource(this.name());
@@ -755,7 +755,7 @@ public enum RegionsData {
 		}
 		@SuppressWarnings("unchecked")
 		@Override
-		public List<UnitedStatesData> getCoronaVirusDataFromExternalSource(ExternalDataService eds) {
+		public List<UnitedStatesData> getCoronaVirusDataFromExternalSource(IExternalDataConnectionService eds) {
 			Logger log = LoggerFactory.getLogger(RegionsData.class);
 			log.info("In the Regions enum for " + this.name() + " about to call makeDataListFromExternalSource with " + eds.toString());
 			return eds.makeDataListFromExternalSource(this.name());
@@ -767,7 +767,7 @@ public enum RegionsData {
 		}
 		@SuppressWarnings("unchecked")
 		@Override
-		public List<UnitedStatesData> getCoronaVirusDataFromExternalSource(ExternalDataService eds) {
+		public List<UnitedStatesData> getCoronaVirusDataFromExternalSource(IExternalDataConnectionService eds) {
 			Logger log = LoggerFactory.getLogger(RegionsData.class);
 			log.info("In the Regions enum for " + this.name() + " about to call makeDataListFromExternalSource with " + eds.toString());
 			return eds.makeDataListFromExternalSource(this.name());
@@ -779,7 +779,7 @@ public enum RegionsData {
 		}
 		@SuppressWarnings("unchecked")
 		@Override
-		public List<UnitedStatesData> getCoronaVirusDataFromExternalSource(ExternalDataService eds) {
+		public List<UnitedStatesData> getCoronaVirusDataFromExternalSource(IExternalDataConnectionService eds) {
 			Logger log = LoggerFactory.getLogger(RegionsData.class);
 			log.info("In the Regions enum for " + this.name() + " about to call makeDataListFromExternalSource with " + eds.toString());
 			return eds.makeDataListFromExternalSource(this.name());
@@ -791,7 +791,7 @@ public enum RegionsData {
 		}
 		@SuppressWarnings("unchecked")
 		@Override
-		public List<UnitedStatesData> getCoronaVirusDataFromExternalSource(ExternalDataService eds) {
+		public List<UnitedStatesData> getCoronaVirusDataFromExternalSource(IExternalDataConnectionService eds) {
 			Logger log = LoggerFactory.getLogger(RegionsData.class);
 			log.info("In the Regions enum for " + this.name() + " about to call makeDataListFromExternalSource with " + eds.toString());
 			return eds.makeDataListFromExternalSource(this.name());
@@ -803,7 +803,7 @@ public enum RegionsData {
 		}
 		@SuppressWarnings("unchecked")
 		@Override
-		public List<UnitedStatesData> getCoronaVirusDataFromExternalSource(ExternalDataService eds) {
+		public List<UnitedStatesData> getCoronaVirusDataFromExternalSource(IExternalDataConnectionService eds) {
 			Logger log = LoggerFactory.getLogger(RegionsData.class);
 			log.info("In the Regions enum for " + this.name() + " about to call makeDataListFromExternalSource with " + eds.toString());
 			return eds.makeDataListFromExternalSource(this.name());
@@ -815,7 +815,7 @@ public enum RegionsData {
 		}
 		@SuppressWarnings("unchecked")
 		@Override
-		public List<UnitedStatesData> getCoronaVirusDataFromExternalSource(ExternalDataService eds) {
+		public List<UnitedStatesData> getCoronaVirusDataFromExternalSource(IExternalDataConnectionService eds) {
 			Logger log = LoggerFactory.getLogger(RegionsData.class);
 			log.info("In the Regions enum for " + this.name() + " about to call makeDataListFromExternalSource with " + eds.toString());
 			return eds.makeDataListFromExternalSource(this.name());
@@ -827,7 +827,7 @@ public enum RegionsData {
 		}
 		@SuppressWarnings("unchecked")
 		@Override
-		public List<UnitedStatesData> getCoronaVirusDataFromExternalSource(ExternalDataService eds) {
+		public List<UnitedStatesData> getCoronaVirusDataFromExternalSource(IExternalDataConnectionService eds) {
 			Logger log = LoggerFactory.getLogger(RegionsData.class);
 			log.info("In the Regions enum for " + this.name() + " about to call makeDataListFromExternalSource with " + eds.toString());
 			return eds.makeDataListFromExternalSource(this.name());
@@ -839,7 +839,7 @@ public enum RegionsData {
 		}
 		@SuppressWarnings("unchecked")
 		@Override
-		public List<UnitedStatesData> getCoronaVirusDataFromExternalSource(ExternalDataService eds) {
+		public List<UnitedStatesData> getCoronaVirusDataFromExternalSource(IExternalDataConnectionService eds) {
 			Logger log = LoggerFactory.getLogger(RegionsData.class);
 			log.info("In the Regions enum for " + this.name() + " about to call makeDataListFromExternalSource with " + eds.toString());
 			return eds.makeDataListFromExternalSource(this.name());
@@ -847,5 +847,5 @@ public enum RegionsData {
 	};
 	
 	public abstract RegionData getRegionData();
-	public abstract <T extends CanonicalCaseDeathData> List<T> getCoronaVirusDataFromExternalSource(ExternalDataService dataService);
+	public abstract <T extends CanonicalCaseDeathData> List<T> getCoronaVirusDataFromExternalSource(IExternalDataConnectionService dataService);
 }

--- a/src/main/java/com/royware/corona/dashboard/enums/regions/RegionsData_OLD_DEL_ME.java
+++ b/src/main/java/com/royware/corona/dashboard/enums/regions/RegionsData_OLD_DEL_ME.java
@@ -8,7 +8,7 @@ import org.springframework.stereotype.Service;
 
 import com.royware.corona.dashboard.enums.data.CacheKeys;
 import com.royware.corona.dashboard.interfaces.data.IExternalDataConnectionService;
-import com.royware.corona.dashboard.interfaces.model.CanonicalCaseDeathData;
+import com.royware.corona.dashboard.interfaces.model.ICanonicalCaseDeathData;
 import com.royware.corona.dashboard.model.data.common.RegionData;
 import com.royware.corona.dashboard.model.data.us.UnitedStatesData;
 import com.royware.corona.dashboard.model.data.world.WorldData;
@@ -847,5 +847,5 @@ public enum RegionsData_OLD_DEL_ME {
 	};
 	
 	public abstract RegionData getRegionData();
-	public abstract <T extends CanonicalCaseDeathData> List<T> getCoronaVirusDataFromExternalSource(IExternalDataConnectionService dataService);
+	public abstract <T extends ICanonicalCaseDeathData> List<T> getCoronaVirusDataFromExternalSource(IExternalDataConnectionService dataService);
 }

--- a/src/main/java/com/royware/corona/dashboard/enums/regions/RegionsData_OLD_DEL_ME.java
+++ b/src/main/java/com/royware/corona/dashboard/enums/regions/RegionsData_OLD_DEL_ME.java
@@ -14,7 +14,7 @@ import com.royware.corona.dashboard.model.data.us.UnitedStatesData;
 import com.royware.corona.dashboard.model.data.world.WorldData;
 
 @Service
-public enum RegionsData {
+public enum RegionsData_OLD_DEL_ME {
 	USA {
 		@Override
 		public RegionData getRegionData() {
@@ -23,7 +23,7 @@ public enum RegionsData {
 		@SuppressWarnings("unchecked")
 		@Override
 		public List<UnitedStatesData> getCoronaVirusDataFromExternalSource(IExternalDataConnectionService eds) {
-			Logger log = LoggerFactory.getLogger(RegionsData.class);
+			Logger log = LoggerFactory.getLogger(RegionsData_OLD_DEL_ME.class);
 			log.info("In the Regions enum for " + this.name() + " about to call makeDataListFromExternalSource with " + eds.toString());
 			return eds.makeDataListFromExternalSource(CacheKeys.CACHE_KEY_US.getName());
 		}
@@ -35,7 +35,7 @@ public enum RegionsData {
 		@SuppressWarnings("unchecked")
 		@Override
 		public List<WorldData> getCoronaVirusDataFromExternalSource(IExternalDataConnectionService eds) {
-			Logger log = LoggerFactory.getLogger(RegionsData.class);
+			Logger log = LoggerFactory.getLogger(RegionsData_OLD_DEL_ME.class);
 			log.info("In the Regions enum for " + this.name() + " about to call makeDataListFromExternalSource with " + eds.toString());
 			return eds.makeDataListFromExternalSource(this.name());
 		}
@@ -47,7 +47,7 @@ public enum RegionsData {
 		@SuppressWarnings("unchecked")
 		@Override
 		public List<WorldData> getCoronaVirusDataFromExternalSource(IExternalDataConnectionService eds) {
-			Logger log = LoggerFactory.getLogger(RegionsData.class);
+			Logger log = LoggerFactory.getLogger(RegionsData_OLD_DEL_ME.class);
 			log.info("In the Regions enum for " + this.name() + " about to call makeDataListFromExternalSource with " + eds.toString());
 			return eds.makeDataListFromExternalSource(this.name());
 		}
@@ -59,7 +59,7 @@ public enum RegionsData {
 		@SuppressWarnings("unchecked")
 		@Override
 		public List<WorldData> getCoronaVirusDataFromExternalSource(IExternalDataConnectionService eds) {
-			Logger log = LoggerFactory.getLogger(RegionsData.class);
+			Logger log = LoggerFactory.getLogger(RegionsData_OLD_DEL_ME.class);
 			log.info("In the Regions enum for " + this.name() + " about to call makeDataListFromExternalSource with " + eds.toString());
 			return eds.makeDataListFromExternalSource(this.name());
 		}
@@ -71,7 +71,7 @@ public enum RegionsData {
 		@SuppressWarnings("unchecked")
 		@Override
 		public List<WorldData> getCoronaVirusDataFromExternalSource(IExternalDataConnectionService eds) {
-			Logger log = LoggerFactory.getLogger(RegionsData.class);
+			Logger log = LoggerFactory.getLogger(RegionsData_OLD_DEL_ME.class);
 			log.info("In the Regions enum for " + this.name() + " about to call makeDataListFromExternalSource with " + eds.toString());
 			return eds.makeDataListFromExternalSource(this.name());
 		}
@@ -83,7 +83,7 @@ public enum RegionsData {
 		@SuppressWarnings("unchecked")
 		@Override
 		public List<WorldData> getCoronaVirusDataFromExternalSource(IExternalDataConnectionService eds) {
-			Logger log = LoggerFactory.getLogger(RegionsData.class);
+			Logger log = LoggerFactory.getLogger(RegionsData_OLD_DEL_ME.class);
 			log.info("In the Regions enum for " + this.name() + " about to call makeDataListFromExternalSource with " + eds.toString());
 			return eds.makeDataListFromExternalSource(this.name());
 		}
@@ -95,7 +95,7 @@ public enum RegionsData {
 		@SuppressWarnings("unchecked")
 		@Override
 		public List<WorldData> getCoronaVirusDataFromExternalSource(IExternalDataConnectionService eds) {
-			Logger log = LoggerFactory.getLogger(RegionsData.class);
+			Logger log = LoggerFactory.getLogger(RegionsData_OLD_DEL_ME.class);
 			log.info("In the Regions enum for " + this.name() + " about to call makeDataListFromExternalSource with " + eds.toString());
 			return eds.makeDataListFromExternalSource(this.name());
 		}
@@ -107,7 +107,7 @@ public enum RegionsData {
 		@SuppressWarnings("unchecked")
 		@Override
 		public List<WorldData> getCoronaVirusDataFromExternalSource(IExternalDataConnectionService eds) {
-			Logger log = LoggerFactory.getLogger(RegionsData.class);
+			Logger log = LoggerFactory.getLogger(RegionsData_OLD_DEL_ME.class);
 			log.info("In the Regions enum for " + this.name() + " about to call makeDataListFromExternalSource with " + eds.toString());
 			return eds.makeDataListFromExternalSource(this.name());
 		}
@@ -119,7 +119,7 @@ public enum RegionsData {
 		@SuppressWarnings("unchecked")
 		@Override
 		public List<WorldData> getCoronaVirusDataFromExternalSource(IExternalDataConnectionService eds) {
-			Logger log = LoggerFactory.getLogger(RegionsData.class);
+			Logger log = LoggerFactory.getLogger(RegionsData_OLD_DEL_ME.class);
 			log.info("In the Regions enum for " + this.name() + " about to call makeDataListFromExternalSource with " + eds.toString());
 			return eds.makeDataListFromExternalSource(this.name());
 		}
@@ -131,7 +131,7 @@ public enum RegionsData {
 		@SuppressWarnings("unchecked")
 		@Override
 		public List<WorldData> getCoronaVirusDataFromExternalSource(IExternalDataConnectionService eds) {
-			Logger log = LoggerFactory.getLogger(RegionsData.class);
+			Logger log = LoggerFactory.getLogger(RegionsData_OLD_DEL_ME.class);
 			log.info("In the Regions enum for " + this.name() + " about to call makeDataListFromExternalSource with " + eds.toString());
 			return eds.makeDataListFromExternalSource(this.name());
 		}
@@ -143,7 +143,7 @@ public enum RegionsData {
 		@SuppressWarnings("unchecked")
 		@Override
 		public List<WorldData> getCoronaVirusDataFromExternalSource(IExternalDataConnectionService eds) {
-			Logger log = LoggerFactory.getLogger(RegionsData.class);
+			Logger log = LoggerFactory.getLogger(RegionsData_OLD_DEL_ME.class);
 			log.info("In the Regions enum for " + this.name() + " about to call makeDataListFromExternalSource with " + eds.toString());
 			return eds.makeDataListFromExternalSource(this.name());
 		}
@@ -155,7 +155,7 @@ public enum RegionsData {
 		@SuppressWarnings("unchecked")
 		@Override
 		public List<WorldData> getCoronaVirusDataFromExternalSource(IExternalDataConnectionService eds) {
-			Logger log = LoggerFactory.getLogger(RegionsData.class);
+			Logger log = LoggerFactory.getLogger(RegionsData_OLD_DEL_ME.class);
 			log.info("In the Regions enum for " + this.name() + " about to call makeDataListFromExternalSource with " + eds.toString());
 			return eds.makeDataListFromExternalSource(this.name());
 		}
@@ -167,7 +167,7 @@ public enum RegionsData {
 		@SuppressWarnings("unchecked")
 		@Override
 		public List<WorldData> getCoronaVirusDataFromExternalSource(IExternalDataConnectionService eds) {
-			Logger log = LoggerFactory.getLogger(RegionsData.class);
+			Logger log = LoggerFactory.getLogger(RegionsData_OLD_DEL_ME.class);
 			log.info("In the Regions enum for " + this.name() + " about to call makeDataListFromExternalSource with " + eds.toString());
 			return eds.makeDataListFromExternalSource(this.name());
 		}
@@ -179,7 +179,7 @@ public enum RegionsData {
 		@SuppressWarnings("unchecked")
 		@Override
 		public List<WorldData> getCoronaVirusDataFromExternalSource(IExternalDataConnectionService eds) {
-			Logger log = LoggerFactory.getLogger(RegionsData.class);
+			Logger log = LoggerFactory.getLogger(RegionsData_OLD_DEL_ME.class);
 			log.info("In the Regions enum for " + this.name() + " about to call makeDataListFromExternalSource with " + eds.toString());
 			return eds.makeDataListFromExternalSource(this.name());
 		}
@@ -191,7 +191,7 @@ public enum RegionsData {
 		@SuppressWarnings("unchecked")
 		@Override
 		public List<WorldData> getCoronaVirusDataFromExternalSource(IExternalDataConnectionService eds) {
-			Logger log = LoggerFactory.getLogger(RegionsData.class);
+			Logger log = LoggerFactory.getLogger(RegionsData_OLD_DEL_ME.class);
 			log.info("In the Regions enum for " + this.name() + " about to call makeDataListFromExternalSource with " + eds.toString());
 			return eds.makeDataListFromExternalSource(this.name());
 		}
@@ -203,7 +203,7 @@ public enum RegionsData {
 		@SuppressWarnings("unchecked")
 		@Override
 		public List<WorldData> getCoronaVirusDataFromExternalSource(IExternalDataConnectionService eds) {
-			Logger log = LoggerFactory.getLogger(RegionsData.class);
+			Logger log = LoggerFactory.getLogger(RegionsData_OLD_DEL_ME.class);
 			log.info("In the Regions enum for " + this.name() + " about to call makeDataListFromExternalSource with " + eds.toString());
 			return eds.makeDataListFromExternalSource(this.name());
 		}
@@ -215,7 +215,7 @@ public enum RegionsData {
 		@SuppressWarnings("unchecked")
 		@Override
 		public List<WorldData> getCoronaVirusDataFromExternalSource(IExternalDataConnectionService eds) {
-			Logger log = LoggerFactory.getLogger(RegionsData.class);
+			Logger log = LoggerFactory.getLogger(RegionsData_OLD_DEL_ME.class);
 			log.info("In the Regions enum for " + this.name() + " about to call makeDataListFromExternalSource with " + eds.toString());
 			return eds.makeDataListFromExternalSource(this.name());
 		}
@@ -228,7 +228,7 @@ public enum RegionsData {
 		@SuppressWarnings("unchecked")
 		@Override
 		public List<UnitedStatesData> getCoronaVirusDataFromExternalSource(IExternalDataConnectionService eds) {
-			Logger log = LoggerFactory.getLogger(RegionsData.class);
+			Logger log = LoggerFactory.getLogger(RegionsData_OLD_DEL_ME.class);
 			log.info("In the Regions enum for " + this.name() + " about to call makeDataListFromExternalSource with " + eds.toString());
 			return eds.makeDataListFromExternalSource("NY");
 		}
@@ -240,7 +240,7 @@ public enum RegionsData {
 		@SuppressWarnings("unchecked")
 		@Override
 		public List<UnitedStatesData> getCoronaVirusDataFromExternalSource(IExternalDataConnectionService eds) {
-			Logger log = LoggerFactory.getLogger(RegionsData.class);
+			Logger log = LoggerFactory.getLogger(RegionsData_OLD_DEL_ME.class);
 			log.info("In the Regions enum for " + this.name() + " about to call makeDataListFromExternalSource with " + eds.toString());
 			return eds.makeDataListFromExternalSource(this.name());
 		}
@@ -252,7 +252,7 @@ public enum RegionsData {
 		@SuppressWarnings("unchecked")
 		@Override
 		public List<UnitedStatesData> getCoronaVirusDataFromExternalSource(IExternalDataConnectionService eds) {
-			Logger log = LoggerFactory.getLogger(RegionsData.class);
+			Logger log = LoggerFactory.getLogger(RegionsData_OLD_DEL_ME.class);
 			log.info("In the Regions enum for " + this.name() + " about to call makeDataListFromExternalSource with " + eds.toString());
 			return eds.makeDataListFromExternalSource(this.name());
 		}
@@ -264,7 +264,7 @@ public enum RegionsData {
 		@SuppressWarnings("unchecked")
 		@Override
 		public List<UnitedStatesData> getCoronaVirusDataFromExternalSource(IExternalDataConnectionService eds) {
-			Logger log = LoggerFactory.getLogger(RegionsData.class);
+			Logger log = LoggerFactory.getLogger(RegionsData_OLD_DEL_ME.class);
 			log.info("In the Regions enum for " + this.name() + " about to call makeDataListFromExternalSource with " + eds.toString());
 			return eds.makeDataListFromExternalSource(this.name());
 		}
@@ -276,7 +276,7 @@ public enum RegionsData {
 		@SuppressWarnings("unchecked")
 		@Override
 		public List<UnitedStatesData> getCoronaVirusDataFromExternalSource(IExternalDataConnectionService eds) {
-			Logger log = LoggerFactory.getLogger(RegionsData.class);
+			Logger log = LoggerFactory.getLogger(RegionsData_OLD_DEL_ME.class);
 			log.info("In the Regions enum for " + this.name() + " about to call makeDataListFromExternalSource with " + eds.toString());
 			return eds.makeDataListFromExternalSource(this.name());
 		}
@@ -288,7 +288,7 @@ public enum RegionsData {
 		@SuppressWarnings("unchecked")
 		@Override
 		public List<UnitedStatesData> getCoronaVirusDataFromExternalSource(IExternalDataConnectionService eds) {
-			Logger log = LoggerFactory.getLogger(RegionsData.class);
+			Logger log = LoggerFactory.getLogger(RegionsData_OLD_DEL_ME.class);
 			log.info("In the Regions enum for " + this.name() + " about to call makeDataListFromExternalSource with " + eds.toString());
 			return eds.makeDataListFromExternalSource(this.name());
 		}
@@ -300,7 +300,7 @@ public enum RegionsData {
 		@SuppressWarnings("unchecked")
 		@Override
 		public List<UnitedStatesData> getCoronaVirusDataFromExternalSource(IExternalDataConnectionService eds) {
-			Logger log = LoggerFactory.getLogger(RegionsData.class);
+			Logger log = LoggerFactory.getLogger(RegionsData_OLD_DEL_ME.class);
 			log.info("In the Regions enum for " + this.name() + " about to call makeDataListFromExternalSource with " + eds.toString());
 			return eds.makeDataListFromExternalSource(this.name());
 		}
@@ -312,7 +312,7 @@ public enum RegionsData {
 		@SuppressWarnings("unchecked")
 		@Override
 		public List<UnitedStatesData> getCoronaVirusDataFromExternalSource(IExternalDataConnectionService eds) {
-			Logger log = LoggerFactory.getLogger(RegionsData.class);
+			Logger log = LoggerFactory.getLogger(RegionsData_OLD_DEL_ME.class);
 			log.info("In the Regions enum for " + this.name() + " about to call makeDataListFromExternalSource with " + eds.toString());
 			return eds.makeDataListFromExternalSource(this.name());
 		}
@@ -324,7 +324,7 @@ public enum RegionsData {
 		@SuppressWarnings("unchecked")
 		@Override
 		public List<UnitedStatesData> getCoronaVirusDataFromExternalSource(IExternalDataConnectionService eds) {
-			Logger log = LoggerFactory.getLogger(RegionsData.class);
+			Logger log = LoggerFactory.getLogger(RegionsData_OLD_DEL_ME.class);
 			log.info("In the Regions enum for " + this.name() + " about to call makeDataListFromExternalSource with " + eds.toString());
 			return eds.makeDataListFromExternalSource(this.name());
 		}
@@ -336,7 +336,7 @@ public enum RegionsData {
 		@SuppressWarnings("unchecked")
 		@Override
 		public List<UnitedStatesData> getCoronaVirusDataFromExternalSource(IExternalDataConnectionService eds) {
-			Logger log = LoggerFactory.getLogger(RegionsData.class);
+			Logger log = LoggerFactory.getLogger(RegionsData_OLD_DEL_ME.class);
 			log.info("In the Regions enum for " + this.name() + " about to call makeDataListFromExternalSource with " + eds.toString());
 			return eds.makeDataListFromExternalSource(this.name());
 		}
@@ -348,7 +348,7 @@ public enum RegionsData {
 		@SuppressWarnings("unchecked")
 		@Override
 		public List<UnitedStatesData> getCoronaVirusDataFromExternalSource(IExternalDataConnectionService eds) {
-			Logger log = LoggerFactory.getLogger(RegionsData.class);
+			Logger log = LoggerFactory.getLogger(RegionsData_OLD_DEL_ME.class);
 			log.info("In the Regions enum for " + this.name() + " about to call makeDataListFromExternalSource with " + eds.toString());
 			return eds.makeDataListFromExternalSource(this.name());
 		}
@@ -360,7 +360,7 @@ public enum RegionsData {
 		@SuppressWarnings("unchecked")
 		@Override
 		public List<UnitedStatesData> getCoronaVirusDataFromExternalSource(IExternalDataConnectionService eds) {
-			Logger log = LoggerFactory.getLogger(RegionsData.class);
+			Logger log = LoggerFactory.getLogger(RegionsData_OLD_DEL_ME.class);
 			log.info("In the Regions enum for " + this.name() + " about to call makeDataListFromExternalSource with " + eds.toString());
 			return eds.makeDataListFromExternalSource(this.name());
 		}
@@ -372,7 +372,7 @@ public enum RegionsData {
 		@SuppressWarnings("unchecked")
 		@Override
 		public List<UnitedStatesData> getCoronaVirusDataFromExternalSource(IExternalDataConnectionService eds) {
-			Logger log = LoggerFactory.getLogger(RegionsData.class);
+			Logger log = LoggerFactory.getLogger(RegionsData_OLD_DEL_ME.class);
 			log.info("In the Regions enum for " + this.name() + " about to call makeDataListFromExternalSource with " + eds.toString());
 			return eds.makeDataListFromExternalSource(this.name());
 		}
@@ -384,7 +384,7 @@ public enum RegionsData {
 		@SuppressWarnings("unchecked")
 		@Override
 		public List<UnitedStatesData> getCoronaVirusDataFromExternalSource(IExternalDataConnectionService eds) {
-			Logger log = LoggerFactory.getLogger(RegionsData.class);
+			Logger log = LoggerFactory.getLogger(RegionsData_OLD_DEL_ME.class);
 			log.info("In the Regions enum for " + this.name() + " about to call makeDataListFromExternalSource with " + eds.toString());
 			return eds.makeDataListFromExternalSource(this.name());
 		}
@@ -396,7 +396,7 @@ public enum RegionsData {
 		@SuppressWarnings("unchecked")
 		@Override
 		public List<UnitedStatesData> getCoronaVirusDataFromExternalSource(IExternalDataConnectionService eds) {
-			Logger log = LoggerFactory.getLogger(RegionsData.class);
+			Logger log = LoggerFactory.getLogger(RegionsData_OLD_DEL_ME.class);
 			log.info("In the Regions enum for " + this.name() + " about to call makeDataListFromExternalSource with " + eds.toString());
 			return eds.makeDataListFromExternalSource(this.name());
 		}
@@ -408,7 +408,7 @@ public enum RegionsData {
 		@SuppressWarnings("unchecked")
 		@Override
 		public List<UnitedStatesData> getCoronaVirusDataFromExternalSource(IExternalDataConnectionService eds) {
-			Logger log = LoggerFactory.getLogger(RegionsData.class);
+			Logger log = LoggerFactory.getLogger(RegionsData_OLD_DEL_ME.class);
 			log.info("In the Regions enum for " + this.name() + " about to call makeDataListFromExternalSource with " + eds.toString());
 			return eds.makeDataListFromExternalSource(this.name());
 		}
@@ -420,7 +420,7 @@ public enum RegionsData {
 		@SuppressWarnings("unchecked")
 		@Override
 		public List<UnitedStatesData> getCoronaVirusDataFromExternalSource(IExternalDataConnectionService eds) {
-			Logger log = LoggerFactory.getLogger(RegionsData.class);
+			Logger log = LoggerFactory.getLogger(RegionsData_OLD_DEL_ME.class);
 			log.info("In the Regions enum for " + this.name() + " about to call makeDataListFromExternalSource with " + eds.toString());
 			return eds.makeDataListFromExternalSource(this.name());
 		}
@@ -432,7 +432,7 @@ public enum RegionsData {
 		@SuppressWarnings("unchecked")
 		@Override
 		public List<UnitedStatesData> getCoronaVirusDataFromExternalSource(IExternalDataConnectionService eds) {
-			Logger log = LoggerFactory.getLogger(RegionsData.class);
+			Logger log = LoggerFactory.getLogger(RegionsData_OLD_DEL_ME.class);
 			log.info("In the Regions enum for " + this.name() + " about to call makeDataListFromExternalSource with " + eds.toString());
 			return eds.makeDataListFromExternalSource(this.name());
 		}
@@ -444,7 +444,7 @@ public enum RegionsData {
 		@SuppressWarnings("unchecked")
 		@Override
 		public List<UnitedStatesData> getCoronaVirusDataFromExternalSource(IExternalDataConnectionService eds) {
-			Logger log = LoggerFactory.getLogger(RegionsData.class);
+			Logger log = LoggerFactory.getLogger(RegionsData_OLD_DEL_ME.class);
 			log.info("In the Regions enum for " + this.name() + " about to call makeDataListFromExternalSource with " + eds.toString());
 			return eds.makeDataListFromExternalSource(this.name());
 		}
@@ -456,7 +456,7 @@ public enum RegionsData {
 		@SuppressWarnings("unchecked")
 		@Override
 		public List<UnitedStatesData> getCoronaVirusDataFromExternalSource(IExternalDataConnectionService eds) {
-			Logger log = LoggerFactory.getLogger(RegionsData.class);
+			Logger log = LoggerFactory.getLogger(RegionsData_OLD_DEL_ME.class);
 			log.info("In the Regions enum for " + this.name() + " about to call makeDataListFromExternalSource with " + eds.toString());
 			return eds.makeDataListFromExternalSource(this.name());
 		}
@@ -468,7 +468,7 @@ public enum RegionsData {
 		@SuppressWarnings("unchecked")
 		@Override
 		public List<UnitedStatesData> getCoronaVirusDataFromExternalSource(IExternalDataConnectionService eds) {
-			Logger log = LoggerFactory.getLogger(RegionsData.class);
+			Logger log = LoggerFactory.getLogger(RegionsData_OLD_DEL_ME.class);
 			log.info("In the Regions enum for " + this.name() + " about to call makeDataListFromExternalSource with " + eds.toString());
 			return eds.makeDataListFromExternalSource(this.name());
 		}
@@ -480,7 +480,7 @@ public enum RegionsData {
 		@SuppressWarnings("unchecked")
 		@Override
 		public List<UnitedStatesData> getCoronaVirusDataFromExternalSource(IExternalDataConnectionService eds) {
-			Logger log = LoggerFactory.getLogger(RegionsData.class);
+			Logger log = LoggerFactory.getLogger(RegionsData_OLD_DEL_ME.class);
 			log.info("In the Regions enum for " + this.name() + " about to call makeDataListFromExternalSource with " + eds.toString());
 			return eds.makeDataListFromExternalSource(this.name());
 		}
@@ -492,7 +492,7 @@ public enum RegionsData {
 		@SuppressWarnings("unchecked")
 		@Override
 		public List<UnitedStatesData> getCoronaVirusDataFromExternalSource(IExternalDataConnectionService eds) {
-			Logger log = LoggerFactory.getLogger(RegionsData.class);
+			Logger log = LoggerFactory.getLogger(RegionsData_OLD_DEL_ME.class);
 			log.info("In the Regions enum for " + this.name() + " about to call makeDataListFromExternalSource with " + eds.toString());
 			return eds.makeDataListFromExternalSource(this.name());
 		}
@@ -504,7 +504,7 @@ public enum RegionsData {
 		@SuppressWarnings("unchecked")
 		@Override
 		public List<UnitedStatesData> getCoronaVirusDataFromExternalSource(IExternalDataConnectionService eds) {
-			Logger log = LoggerFactory.getLogger(RegionsData.class);
+			Logger log = LoggerFactory.getLogger(RegionsData_OLD_DEL_ME.class);
 			log.info("In the Regions enum for " + this.name() + " about to call makeDataListFromExternalSource with " + eds.toString());
 			return eds.makeDataListFromExternalSource(this.name());
 		}
@@ -516,7 +516,7 @@ public enum RegionsData {
 		@SuppressWarnings("unchecked")
 		@Override
 		public List<UnitedStatesData> getCoronaVirusDataFromExternalSource(IExternalDataConnectionService eds) {
-			Logger log = LoggerFactory.getLogger(RegionsData.class);
+			Logger log = LoggerFactory.getLogger(RegionsData_OLD_DEL_ME.class);
 			log.info("In the Regions enum for " + this.name() + " about to call makeDataListFromExternalSource with " + eds.toString());
 			return eds.makeDataListFromExternalSource(this.name());
 		}
@@ -528,7 +528,7 @@ public enum RegionsData {
 		@SuppressWarnings("unchecked")
 		@Override
 		public List<UnitedStatesData> getCoronaVirusDataFromExternalSource(IExternalDataConnectionService eds) {
-			Logger log = LoggerFactory.getLogger(RegionsData.class);
+			Logger log = LoggerFactory.getLogger(RegionsData_OLD_DEL_ME.class);
 			log.info("In the Regions enum for " + this.name() + " about to call makeDataListFromExternalSource with " + eds.toString());
 			return eds.makeDataListFromExternalSource(this.name());
 		}
@@ -540,7 +540,7 @@ public enum RegionsData {
 		@SuppressWarnings("unchecked")
 		@Override
 		public List<UnitedStatesData> getCoronaVirusDataFromExternalSource(IExternalDataConnectionService eds) {
-			Logger log = LoggerFactory.getLogger(RegionsData.class);
+			Logger log = LoggerFactory.getLogger(RegionsData_OLD_DEL_ME.class);
 			log.info("In the Regions enum for " + this.name() + " about to call makeDataListFromExternalSource with " + eds.toString());
 			return eds.makeDataListFromExternalSource(this.name());
 		}
@@ -552,7 +552,7 @@ public enum RegionsData {
 		@SuppressWarnings("unchecked")
 		@Override
 		public List<UnitedStatesData> getCoronaVirusDataFromExternalSource(IExternalDataConnectionService eds) {
-			Logger log = LoggerFactory.getLogger(RegionsData.class);
+			Logger log = LoggerFactory.getLogger(RegionsData_OLD_DEL_ME.class);
 			log.info("In the Regions enum for " + this.name() + " about to call makeDataListFromExternalSource with " + eds.toString());
 			return eds.makeDataListFromExternalSource(this.name());
 		}
@@ -564,7 +564,7 @@ public enum RegionsData {
 		@SuppressWarnings("unchecked")
 		@Override
 		public List<UnitedStatesData> getCoronaVirusDataFromExternalSource(IExternalDataConnectionService eds) {
-			Logger log = LoggerFactory.getLogger(RegionsData.class);
+			Logger log = LoggerFactory.getLogger(RegionsData_OLD_DEL_ME.class);
 			log.info("In the Regions enum for " + this.name() + " about to call makeDataListFromExternalSource with " + eds.toString());
 			return eds.makeDataListFromExternalSource(this.name());
 		}
@@ -576,7 +576,7 @@ public enum RegionsData {
 		@SuppressWarnings("unchecked")
 		@Override
 		public List<UnitedStatesData> getCoronaVirusDataFromExternalSource(IExternalDataConnectionService eds) {
-			Logger log = LoggerFactory.getLogger(RegionsData.class);
+			Logger log = LoggerFactory.getLogger(RegionsData_OLD_DEL_ME.class);
 			log.info("In the Regions enum for " + this.name() + " about to call makeDataListFromExternalSource with " + eds.toString());
 			return eds.makeDataListFromExternalSource(this.name());
 		}
@@ -588,7 +588,7 @@ public enum RegionsData {
 		@SuppressWarnings("unchecked")
 		@Override
 		public List<UnitedStatesData> getCoronaVirusDataFromExternalSource(IExternalDataConnectionService eds) {
-			Logger log = LoggerFactory.getLogger(RegionsData.class);
+			Logger log = LoggerFactory.getLogger(RegionsData_OLD_DEL_ME.class);
 			log.info("In the Regions enum for " + this.name() + " about to call makeDataListFromExternalSource with " + eds.toString());
 			return eds.makeDataListFromExternalSource(this.name());
 		}
@@ -600,7 +600,7 @@ public enum RegionsData {
 		@SuppressWarnings("unchecked")
 		@Override
 		public List<UnitedStatesData> getCoronaVirusDataFromExternalSource(IExternalDataConnectionService eds) {
-			Logger log = LoggerFactory.getLogger(RegionsData.class);
+			Logger log = LoggerFactory.getLogger(RegionsData_OLD_DEL_ME.class);
 			log.info("In the Regions enum for " + this.name() + " about to call makeDataListFromExternalSource with " + eds.toString());
 			return eds.makeDataListFromExternalSource(this.name());
 		}
@@ -612,7 +612,7 @@ public enum RegionsData {
 		@SuppressWarnings("unchecked")
 		@Override
 		public List<UnitedStatesData> getCoronaVirusDataFromExternalSource(IExternalDataConnectionService eds) {
-			Logger log = LoggerFactory.getLogger(RegionsData.class);
+			Logger log = LoggerFactory.getLogger(RegionsData_OLD_DEL_ME.class);
 			log.info("In the Regions enum for " + this.name() + " about to call makeDataListFromExternalSource with " + eds.toString());
 			return eds.makeDataListFromExternalSource(this.name());
 		}
@@ -624,7 +624,7 @@ public enum RegionsData {
 		@SuppressWarnings("unchecked")
 		@Override
 		public List<UnitedStatesData> getCoronaVirusDataFromExternalSource(IExternalDataConnectionService eds) {
-			Logger log = LoggerFactory.getLogger(RegionsData.class);
+			Logger log = LoggerFactory.getLogger(RegionsData_OLD_DEL_ME.class);
 			log.info("In the Regions enum for " + this.name() + " about to call makeDataListFromExternalSource with " + eds.toString());
 			return eds.makeDataListFromExternalSource(this.name());
 		}
@@ -636,7 +636,7 @@ public enum RegionsData {
 		@SuppressWarnings("unchecked")
 		@Override
 		public List<UnitedStatesData> getCoronaVirusDataFromExternalSource(IExternalDataConnectionService eds) {
-			Logger log = LoggerFactory.getLogger(RegionsData.class);
+			Logger log = LoggerFactory.getLogger(RegionsData_OLD_DEL_ME.class);
 			log.info("In the Regions enum for " + this.name() + " about to call makeDataListFromExternalSource with " + eds.toString());
 			return eds.makeDataListFromExternalSource(this.name());
 		}
@@ -648,7 +648,7 @@ public enum RegionsData {
 		@SuppressWarnings("unchecked")
 		@Override
 		public List<UnitedStatesData> getCoronaVirusDataFromExternalSource(IExternalDataConnectionService eds) {
-			Logger log = LoggerFactory.getLogger(RegionsData.class);
+			Logger log = LoggerFactory.getLogger(RegionsData_OLD_DEL_ME.class);
 			log.info("In the Regions enum for " + this.name() + " about to call makeDataListFromExternalSource with " + eds.toString());
 			return eds.makeDataListFromExternalSource(this.name());
 		}
@@ -660,7 +660,7 @@ public enum RegionsData {
 		@SuppressWarnings("unchecked")
 		@Override
 		public List<UnitedStatesData> getCoronaVirusDataFromExternalSource(IExternalDataConnectionService eds) {
-			Logger log = LoggerFactory.getLogger(RegionsData.class);
+			Logger log = LoggerFactory.getLogger(RegionsData_OLD_DEL_ME.class);
 			log.info("In the Regions enum for " + this.name() + " about to call makeDataListFromExternalSource with " + eds.toString());
 			return eds.makeDataListFromExternalSource(this.name());
 		}
@@ -672,7 +672,7 @@ public enum RegionsData {
 		@SuppressWarnings("unchecked")
 		@Override
 		public List<UnitedStatesData> getCoronaVirusDataFromExternalSource(IExternalDataConnectionService eds) {
-			Logger log = LoggerFactory.getLogger(RegionsData.class);
+			Logger log = LoggerFactory.getLogger(RegionsData_OLD_DEL_ME.class);
 			log.info("In the Regions enum for " + this.name() + " about to call makeDataListFromExternalSource with " + eds.toString());
 			return eds.makeDataListFromExternalSource(this.name());
 		}
@@ -684,7 +684,7 @@ public enum RegionsData {
 		@SuppressWarnings("unchecked")
 		@Override
 		public List<UnitedStatesData> getCoronaVirusDataFromExternalSource(IExternalDataConnectionService eds) {
-			Logger log = LoggerFactory.getLogger(RegionsData.class);
+			Logger log = LoggerFactory.getLogger(RegionsData_OLD_DEL_ME.class);
 			log.info("In the Regions enum for " + this.name() + " about to call makeDataListFromExternalSource with " + eds.toString());
 			return eds.makeDataListFromExternalSource(this.name());
 		}
@@ -696,7 +696,7 @@ public enum RegionsData {
 		@SuppressWarnings("unchecked")
 		@Override
 		public List<UnitedStatesData> getCoronaVirusDataFromExternalSource(IExternalDataConnectionService eds) {
-			Logger log = LoggerFactory.getLogger(RegionsData.class);
+			Logger log = LoggerFactory.getLogger(RegionsData_OLD_DEL_ME.class);
 			log.info("In the Regions enum for " + this.name() + " about to call makeDataListFromExternalSource with " + eds.toString());
 			return eds.makeDataListFromExternalSource(this.name());
 		}
@@ -708,7 +708,7 @@ public enum RegionsData {
 		@SuppressWarnings("unchecked")
 		@Override
 		public List<UnitedStatesData> getCoronaVirusDataFromExternalSource(IExternalDataConnectionService eds) {
-			Logger log = LoggerFactory.getLogger(RegionsData.class);
+			Logger log = LoggerFactory.getLogger(RegionsData_OLD_DEL_ME.class);
 			log.info("In the Regions enum for " + this.name() + " about to call makeDataListFromExternalSource with " + eds.toString());
 			return eds.makeDataListFromExternalSource(this.name());
 		}
@@ -720,7 +720,7 @@ public enum RegionsData {
 		@SuppressWarnings("unchecked")
 		@Override
 		public List<UnitedStatesData> getCoronaVirusDataFromExternalSource(IExternalDataConnectionService eds) {
-			Logger log = LoggerFactory.getLogger(RegionsData.class);
+			Logger log = LoggerFactory.getLogger(RegionsData_OLD_DEL_ME.class);
 			log.info("In the Regions enum for " + this.name() + " about to call makeDataListFromExternalSource with " + eds.toString());
 			return eds.makeDataListFromExternalSource(this.name());
 		}
@@ -732,7 +732,7 @@ public enum RegionsData {
 		@SuppressWarnings("unchecked")
 		@Override
 		public List<UnitedStatesData> getCoronaVirusDataFromExternalSource(IExternalDataConnectionService eds) {
-			Logger log = LoggerFactory.getLogger(RegionsData.class);
+			Logger log = LoggerFactory.getLogger(RegionsData_OLD_DEL_ME.class);
 			log.info("In the Regions enum for " + this.name() + " about to call makeDataListFromExternalSource with " + eds.toString());
 			return eds.makeDataListFromExternalSource(this.name());
 		}
@@ -744,7 +744,7 @@ public enum RegionsData {
 		@SuppressWarnings("unchecked")
 		@Override
 		public List<UnitedStatesData> getCoronaVirusDataFromExternalSource(IExternalDataConnectionService eds) {
-			Logger log = LoggerFactory.getLogger(RegionsData.class);
+			Logger log = LoggerFactory.getLogger(RegionsData_OLD_DEL_ME.class);
 			log.info("In the Regions enum for " + this.name() + " about to call makeDataListFromExternalSource with " + eds.toString());
 			return eds.makeDataListFromExternalSource(this.name());
 		}
@@ -756,7 +756,7 @@ public enum RegionsData {
 		@SuppressWarnings("unchecked")
 		@Override
 		public List<UnitedStatesData> getCoronaVirusDataFromExternalSource(IExternalDataConnectionService eds) {
-			Logger log = LoggerFactory.getLogger(RegionsData.class);
+			Logger log = LoggerFactory.getLogger(RegionsData_OLD_DEL_ME.class);
 			log.info("In the Regions enum for " + this.name() + " about to call makeDataListFromExternalSource with " + eds.toString());
 			return eds.makeDataListFromExternalSource(this.name());
 		}
@@ -768,7 +768,7 @@ public enum RegionsData {
 		@SuppressWarnings("unchecked")
 		@Override
 		public List<UnitedStatesData> getCoronaVirusDataFromExternalSource(IExternalDataConnectionService eds) {
-			Logger log = LoggerFactory.getLogger(RegionsData.class);
+			Logger log = LoggerFactory.getLogger(RegionsData_OLD_DEL_ME.class);
 			log.info("In the Regions enum for " + this.name() + " about to call makeDataListFromExternalSource with " + eds.toString());
 			return eds.makeDataListFromExternalSource(this.name());
 		}
@@ -780,7 +780,7 @@ public enum RegionsData {
 		@SuppressWarnings("unchecked")
 		@Override
 		public List<UnitedStatesData> getCoronaVirusDataFromExternalSource(IExternalDataConnectionService eds) {
-			Logger log = LoggerFactory.getLogger(RegionsData.class);
+			Logger log = LoggerFactory.getLogger(RegionsData_OLD_DEL_ME.class);
 			log.info("In the Regions enum for " + this.name() + " about to call makeDataListFromExternalSource with " + eds.toString());
 			return eds.makeDataListFromExternalSource(this.name());
 		}
@@ -792,7 +792,7 @@ public enum RegionsData {
 		@SuppressWarnings("unchecked")
 		@Override
 		public List<UnitedStatesData> getCoronaVirusDataFromExternalSource(IExternalDataConnectionService eds) {
-			Logger log = LoggerFactory.getLogger(RegionsData.class);
+			Logger log = LoggerFactory.getLogger(RegionsData_OLD_DEL_ME.class);
 			log.info("In the Regions enum for " + this.name() + " about to call makeDataListFromExternalSource with " + eds.toString());
 			return eds.makeDataListFromExternalSource(this.name());
 		}
@@ -804,7 +804,7 @@ public enum RegionsData {
 		@SuppressWarnings("unchecked")
 		@Override
 		public List<UnitedStatesData> getCoronaVirusDataFromExternalSource(IExternalDataConnectionService eds) {
-			Logger log = LoggerFactory.getLogger(RegionsData.class);
+			Logger log = LoggerFactory.getLogger(RegionsData_OLD_DEL_ME.class);
 			log.info("In the Regions enum for " + this.name() + " about to call makeDataListFromExternalSource with " + eds.toString());
 			return eds.makeDataListFromExternalSource(this.name());
 		}
@@ -816,7 +816,7 @@ public enum RegionsData {
 		@SuppressWarnings("unchecked")
 		@Override
 		public List<UnitedStatesData> getCoronaVirusDataFromExternalSource(IExternalDataConnectionService eds) {
-			Logger log = LoggerFactory.getLogger(RegionsData.class);
+			Logger log = LoggerFactory.getLogger(RegionsData_OLD_DEL_ME.class);
 			log.info("In the Regions enum for " + this.name() + " about to call makeDataListFromExternalSource with " + eds.toString());
 			return eds.makeDataListFromExternalSource(this.name());
 		}
@@ -828,7 +828,7 @@ public enum RegionsData {
 		@SuppressWarnings("unchecked")
 		@Override
 		public List<UnitedStatesData> getCoronaVirusDataFromExternalSource(IExternalDataConnectionService eds) {
-			Logger log = LoggerFactory.getLogger(RegionsData.class);
+			Logger log = LoggerFactory.getLogger(RegionsData_OLD_DEL_ME.class);
 			log.info("In the Regions enum for " + this.name() + " about to call makeDataListFromExternalSource with " + eds.toString());
 			return eds.makeDataListFromExternalSource(this.name());
 		}
@@ -840,7 +840,7 @@ public enum RegionsData {
 		@SuppressWarnings("unchecked")
 		@Override
 		public List<UnitedStatesData> getCoronaVirusDataFromExternalSource(IExternalDataConnectionService eds) {
-			Logger log = LoggerFactory.getLogger(RegionsData.class);
+			Logger log = LoggerFactory.getLogger(RegionsData_OLD_DEL_ME.class);
 			log.info("In the Regions enum for " + this.name() + " about to call makeDataListFromExternalSource with " + eds.toString());
 			return eds.makeDataListFromExternalSource(this.name());
 		}

--- a/src/main/java/com/royware/corona/dashboard/enums/regions/RegionsInDashboard.java
+++ b/src/main/java/com/royware/corona/dashboard/enums/regions/RegionsInDashboard.java
@@ -1,0 +1,103 @@
+package com.royware.corona.dashboard.enums.regions;
+
+public enum RegionsInDashboard {
+	USA(328200000, RegionTypes.COUNTRY, "United States"),
+	USA_NO_NY(328200000 - 19450000, RegionTypes.COUNTRY, "U.S. w/o N.Y."),
+	AUS(24990000, RegionTypes.COUNTRY, "Australia"),
+	CAN(37590000, RegionTypes.COUNTRY, "Canada"),
+	CHN(1393000000, RegionTypes.COUNTRY, "China"),
+	DEU(83020000, RegionTypes.COUNTRY, "Germany"),
+	ESP(46940000, RegionTypes.COUNTRY, "Spain"),
+	FRA(66990000, RegionTypes.COUNTRY, "France"),
+	GBR(66650000, RegionTypes.COUNTRY, "Great Britain"),
+	IND(1390885000, RegionTypes.COUNTRY, "India"),
+	ITA(60360000, RegionTypes.COUNTRY, "Italy"),
+	JPN(126500000, RegionTypes.COUNTRY, "Japan"),
+	KOR(51640000, RegionTypes.COUNTRY, "South Korea"),
+	MEX(126200000, RegionTypes.COUNTRY, "Mexico"),
+	NOR(5638000, RegionTypes.COUNTRY, "Norway"),
+	PRI(3194000, RegionTypes.COUNTRY, "Puerto Rico"),
+	SGP(5639000, RegionTypes.COUNTRY, "Singapore"),
+	SWE(10230000, RegionTypes.COUNTRY, "Sweden"),
+	AL(4903000, RegionTypes.STATE, "Alabama"),
+	AK(731545, RegionTypes.STATE, "Alaska"),
+	AR(3018000, RegionTypes.STATE, "Arkansas"),
+	AZ(7279000, RegionTypes.STATE, "Arizona"),
+	CA(39510000, RegionTypes.STATE, "California"),
+	CO(5759000, RegionTypes.STATE, "Colorado"),
+	CT(3565000, RegionTypes.STATE, "Connecticut"),
+	DE(973764, RegionTypes.STATE, "Delaware"),
+	FL(21480000, RegionTypes.STATE, "Florida"),
+	GA(10620000, RegionTypes.STATE, "Georgia"),
+	HI(1416000, RegionTypes.STATE, "Hawaii"),
+	IA(3155000, RegionTypes.STATE, "Iowa"),
+	ID(1787000, RegionTypes.STATE, "Idaho"),
+	IL(12670000, RegionTypes.STATE, "Illinois"),
+	IN(6732000, RegionTypes.STATE, "Indiana"),
+	KS(2913000, RegionTypes.STATE, "Kansas"),
+	KY(4468000, RegionTypes.STATE, "Kentucky"),
+	LA(3990000, RegionTypes.STATE, "Louisiana"),
+	MA(6893000, RegionTypes.STATE, "Massachusetts"),
+	MD(6046000, RegionTypes.STATE, "Maryland"),
+	ME(1344000, RegionTypes.STATE, "Maine"),
+	MI(9987000, RegionTypes.STATE, "Michigan"),
+	MN(5640000, RegionTypes.STATE, "Minnesota"),
+	MO(6137000, RegionTypes.STATE, "Missouri"),
+	MS(2976000, RegionTypes.STATE, "Mississippi"),
+	MT(1069000, RegionTypes.STATE, "Montana"),
+	NC(10490000, RegionTypes.STATE, "North Carolina"),
+	ND(762062, RegionTypes.STATE, "North Dakota"),
+	NE(1934000, RegionTypes.STATE, "Nebraska"),
+	NH(1360000, RegionTypes.STATE, "New Hampshire"),
+	NJ(8882000, RegionTypes.STATE, "New Jersey"),
+	NM(2097000, RegionTypes.STATE, "New Mexico"),
+	NV(3080000, RegionTypes.STATE, "Nevada"),
+	NY(19450000, RegionTypes.STATE, "New York"),
+	OH(11690000, RegionTypes.STATE, "Ohio"),
+	OK(3957000, RegionTypes.STATE, "Oklahoma"),
+	OR(4218000, RegionTypes.STATE, "Oregon"),
+	PA(12800000, RegionTypes.STATE, "Pennsylvania"),
+	RI(1059000, RegionTypes.STATE, "Rhode Island"),
+	SC(5149000, RegionTypes.STATE, "South Carolina"),
+	SD(884659, RegionTypes.STATE, "South Dakota"),
+	TN(6829000, RegionTypes.STATE, "Tennessee"),
+	TX(29000000, RegionTypes.STATE, "Texas"),
+	UT(3206000, RegionTypes.STATE, "Utah"),
+	VA(8536000, RegionTypes.STATE, "Virginia"),
+	VT(623989, RegionTypes.STATE, "Vermont"),
+	WA(7615000, RegionTypes.STATE, "Washington"),
+	WV(1792000, RegionTypes.STATE, "West Virginia"),
+	WI(5822000, RegionTypes.STATE, "Wisconsin"),
+	WY(578759, RegionTypes.STATE, "Wyoming"),
+	DC(702455, RegionTypes.STATE, "District of Columbia");
+	
+	private final int regionPopulation;
+	private final RegionTypes regionType;
+	private final String label;
+	private RegionsInDashboard(int regionPop, RegionTypes regionType, String label) {
+		this.regionPopulation = regionPop;
+		this.regionType = regionType;
+		this.label = label;
+	}
+	
+	public int getPopulation() {
+		return this.regionPopulation;
+	}
+	
+	public RegionTypes getRegionType() {
+		return this.regionType;
+	}
+	
+	public String getLabel() {
+		return this.label;
+	}
+	
+	public static RegionsInDashboard valueOfLabel(String label) {
+		for(RegionsInDashboard e : values()) {
+			if(label.equalsIgnoreCase(e.label)) {
+				return e;
+			}
+		}
+		return null;
+	}
+}

--- a/src/main/java/com/royware/corona/dashboard/enums/regions/RegionsInDashboard.java
+++ b/src/main/java/com/royware/corona/dashboard/enums/regions/RegionsInDashboard.java
@@ -100,4 +100,13 @@ public enum RegionsInDashboard {
 		}
 		return null;
 	}
+	
+	public static RegionsInDashboard valueOfEnum(String enumAsString) {
+		for(RegionsInDashboard e : values()) {
+			if(enumAsString.equalsIgnoreCase(e.name())) {
+				return e;
+			}
+		}
+		return null;
+	}
 }

--- a/src/main/java/com/royware/corona/dashboard/interfaces/chartlist/IChartListMaker.java
+++ b/src/main/java/com/royware/corona/dashboard/interfaces/chartlist/IChartListMaker.java
@@ -5,7 +5,7 @@ import java.util.Map;
 
 import org.springframework.stereotype.Service;
 
-import com.royware.corona.dashboard.interfaces.model.CanonicalCaseDeathData;
+import com.royware.corona.dashboard.interfaces.model.ICanonicalCaseDeathData;
 
 @Service
 public interface IChartListMaker {
@@ -14,5 +14,5 @@ public interface IChartListMaker {
 	//TESTS WILL ALWAYS START WITH INDEX = 0 --> DAY = 0
 	//HOSPITALIZATIONS WILL HAVE A VARIABLE-INDEX --> DAY = 0 (DATA NOT ALWAYS AVAILABLE AMONG REGIONS)
 	
-	public <T extends CanonicalCaseDeathData> List<List<Map<Object, Object>>> makeListFrom(List<T> regionDataList, int regionPopulation);
+	public <T extends ICanonicalCaseDeathData> List<List<Map<Object, Object>>> makeListFrom(List<T> regionDataList, int regionPopulation);
 }

--- a/src/main/java/com/royware/corona/dashboard/interfaces/chartlist/IChartListStore.java
+++ b/src/main/java/com/royware/corona/dashboard/interfaces/chartlist/IChartListStore.java
@@ -6,11 +6,11 @@ import java.util.Map;
 import org.springframework.stereotype.Service;
 
 import com.royware.corona.dashboard.enums.charts.ChartTypes;
-import com.royware.corona.dashboard.interfaces.model.CanonicalCaseDeathData;
+import com.royware.corona.dashboard.interfaces.model.ICanonicalCaseDeathData;
 
 @Service
 public interface IChartListStore {
-	public <T extends CanonicalCaseDeathData> List<List<Map<Object, Object>>> produceChartListFromRegionData(
+	public <T extends ICanonicalCaseDeathData> List<List<Map<Object, Object>>> produceChartListFromRegionData(
 			ChartTypes type,
 			List<T> regionDataList,
 			int regionPopulation);

--- a/src/main/java/com/royware/corona/dashboard/interfaces/dashboard/IDashStatsMaker.java
+++ b/src/main/java/com/royware/corona/dashboard/interfaces/dashboard/IDashStatsMaker.java
@@ -5,12 +5,12 @@ import java.util.Map;
 
 import org.springframework.stereotype.Service;
 
-import com.royware.corona.dashboard.interfaces.model.CanonicalCaseDeathData;
+import com.royware.corona.dashboard.interfaces.model.ICanonicalCaseDeathData;
 import com.royware.corona.dashboard.model.dashboard.DashboardStatistics;
 
 @Service
 public interface IDashStatsMaker {
-	public <T extends CanonicalCaseDeathData, C extends List<M>, M extends Map<Object, Object>> DashboardStatistics
+	public <T extends ICanonicalCaseDeathData, C extends List<M>, M extends Map<Object, Object>> DashboardStatistics
 		makeStats(
 			DashboardStatistics dashStats,
 			List<T> dataList,

--- a/src/main/java/com/royware/corona/dashboard/interfaces/dashboard/IDashStatsStore.java
+++ b/src/main/java/com/royware/corona/dashboard/interfaces/dashboard/IDashStatsStore.java
@@ -6,12 +6,12 @@ import java.util.Map;
 import org.springframework.stereotype.Service;
 
 import com.royware.corona.dashboard.enums.dashstats.DashStatsTypes;
-import com.royware.corona.dashboard.interfaces.model.CanonicalCaseDeathData;
+import com.royware.corona.dashboard.interfaces.model.ICanonicalCaseDeathData;
 import com.royware.corona.dashboard.model.dashboard.DashboardStatistics;
 
 @Service
 public interface IDashStatsStore {
-	public <T extends CanonicalCaseDeathData, C extends List<M>, M extends Map<Object, Object>> DashboardStatistics
+	public <T extends ICanonicalCaseDeathData, C extends List<M>, M extends Map<Object, Object>> DashboardStatistics
 	produceDashboardStatsForType(
 		DashStatsTypes statsType,
 		DashboardStatistics dashStats,

--- a/src/main/java/com/royware/corona/dashboard/interfaces/dashboard/IDashboardChartService.java
+++ b/src/main/java/com/royware/corona/dashboard/interfaces/dashboard/IDashboardChartService.java
@@ -4,12 +4,12 @@ import java.util.List;
 
 import org.springframework.stereotype.Service;
 
-import com.royware.corona.dashboard.interfaces.model.CanonicalCaseDeathData;
+import com.royware.corona.dashboard.interfaces.model.ICanonicalCaseDeathData;
 import com.royware.corona.dashboard.model.dashboard.DashboardChart;
 import com.royware.corona.dashboard.model.dashboard.DashboardStatistics;
 
 @Service
-public interface DashboardChartService {
-	public <T extends CanonicalCaseDeathData> List<DashboardChart> makeAllDashboardChartsAndStats(
+public interface IDashboardChartService {
+	public <T extends ICanonicalCaseDeathData> List<DashboardChart> makeAllDashboardChartsAndStats(
 			List<T> caseList, String region, Integer regionPopulation, DashboardStatistics dashStats);	
 }

--- a/src/main/java/com/royware/corona/dashboard/interfaces/dashboard/IDashboardConfigService.java
+++ b/src/main/java/com/royware/corona/dashboard/interfaces/dashboard/IDashboardConfigService.java
@@ -4,7 +4,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.ui.ModelMap;
 
 @Service
-public interface DashboardConfigService {
+public interface IDashboardConfigService {
 	public static String ALL_STATES_AS_CSV = "AL,AK,AZ,AR,CA,CO,CT,DE,FL,GA,HI,ID,IL,IN,IA,KS,KY,LA,ME,MD,MA,MI,MN,MS,MO,MT,NE,NV,NH,NJ,NM,NY,NC,ND,OH,OK,OR,PA,RI,SC,SD,TN,TX,UT,VT,VA,WA,WV,WI,WY";
 	
 	public boolean populateDashboardModelMap(String region, ModelMap map);

--- a/src/main/java/com/royware/corona/dashboard/interfaces/data/ExternalDataServiceFactory.java
+++ b/src/main/java/com/royware/corona/dashboard/interfaces/data/ExternalDataServiceFactory.java
@@ -1,5 +1,5 @@
 package com.royware.corona.dashboard.interfaces.data;
 
 public interface ExternalDataServiceFactory {
-	public ExternalDataService getExternalDataService(String typeOfService);
+	public IExternalDataConnectionService getExternalDataService(String typeOfService);
 }

--- a/src/main/java/com/royware/corona/dashboard/interfaces/data/ICacheActions.java
+++ b/src/main/java/com/royware/corona/dashboard/interfaces/data/ICacheActions.java
@@ -4,7 +4,7 @@ import java.util.List;
 
 import org.springframework.stereotype.Service;
 
-import com.royware.corona.dashboard.interfaces.model.CanonicalCaseDeathData;
+import com.royware.corona.dashboard.interfaces.model.ICanonicalCaseDeathData;
 
 @Service
 public interface ICacheActions {
@@ -12,6 +12,6 @@ public interface ICacheActions {
 	
 	public void cacheEvictAndRepopulate();
 	public void evictCache();
-	public <T extends CanonicalCaseDeathData> void populateCacheFromDataList(String cacheName, List<T> newCacheData);
+	public <T extends ICanonicalCaseDeathData> void populateCacheFromDataList(String cacheName, List<T> newCacheData);
 	public void populateCacheFromSource(String cacheName);
 }

--- a/src/main/java/com/royware/corona/dashboard/interfaces/data/IExternalDataConnectionService.java
+++ b/src/main/java/com/royware/corona/dashboard/interfaces/data/IExternalDataConnectionService.java
@@ -4,7 +4,7 @@ import java.util.List;
 
 import com.royware.corona.dashboard.interfaces.model.CanonicalCaseDeathData;
 
-public interface ExternalDataService {
+public interface IExternalDataConnectionService {
 	public static final int US_CUTOFF_DATE = 20200304;
 	
 	public <T extends CanonicalCaseDeathData> List<T> makeDataListFromExternalSource(String cacheKey);

--- a/src/main/java/com/royware/corona/dashboard/interfaces/data/IExternalDataConnectionService.java
+++ b/src/main/java/com/royware/corona/dashboard/interfaces/data/IExternalDataConnectionService.java
@@ -2,10 +2,10 @@ package com.royware.corona.dashboard.interfaces.data;
 
 import java.util.List;
 
-import com.royware.corona.dashboard.interfaces.model.CanonicalCaseDeathData;
+import com.royware.corona.dashboard.interfaces.model.ICanonicalCaseDeathData;
 
 public interface IExternalDataConnectionService {
 	public static final int US_CUTOFF_DATE = 20200304;
 	
-	public <T extends CanonicalCaseDeathData> List<T> makeDataListFromExternalSource(String cacheKey);
+	public <T extends ICanonicalCaseDeathData> List<T> makeDataListFromExternalSource(String cacheKey);
 }

--- a/src/main/java/com/royware/corona/dashboard/interfaces/data/IExternalDataServiceFactory.java
+++ b/src/main/java/com/royware/corona/dashboard/interfaces/data/IExternalDataServiceFactory.java
@@ -1,5 +1,5 @@
 package com.royware.corona.dashboard.interfaces.data;
 
-public interface ExternalDataServiceFactory {
+public interface IExternalDataServiceFactory {
 	public IExternalDataConnectionService getExternalDataService(String typeOfService);
 }

--- a/src/main/java/com/royware/corona/dashboard/interfaces/data/IMultiRegionExternalDataService.java
+++ b/src/main/java/com/royware/corona/dashboard/interfaces/data/IMultiRegionExternalDataService.java
@@ -10,5 +10,5 @@ import com.royware.corona.dashboard.model.data.us.UnitedStatesData;
 public interface IMultiRegionExternalDataService {
 	public String getStatesFromMultiRegionString(String region);
 	public int getMultiRegionPopulation(String fullRegionName);
-	public List<UnitedStatesData> getMultiRegionDataFromExternalSource(String fullRegionName, ExternalDataService dataService);
+	public List<UnitedStatesData> getMultiRegionDataFromExternalSource(String fullRegionName, IExternalDataConnectionService dataService);
 }

--- a/src/main/java/com/royware/corona/dashboard/interfaces/data/IMultiRegionListStitcher.java
+++ b/src/main/java/com/royware/corona/dashboard/interfaces/data/IMultiRegionListStitcher.java
@@ -12,6 +12,6 @@ public interface IMultiRegionListStitcher {
 
 	List<UnitedStatesData> stitchMultiStateListsIntoOneList(Map<String, List<UnitedStatesData>> mapOfStateDataLists, String[] states);
 
-	Map<String, List<UnitedStatesData>> makeMapOfStateDataLists(ExternalDataService dataService, String[] states);
+	Map<String, List<UnitedStatesData>> makeMapOfStateDataLists(IExternalDataConnectionService dataService, String[] states);
 
 }

--- a/src/main/java/com/royware/corona/dashboard/interfaces/data/IWorldDataServiceCaller.java
+++ b/src/main/java/com/royware/corona/dashboard/interfaces/data/IWorldDataServiceCaller.java
@@ -7,6 +7,6 @@ import org.springframework.stereotype.Service;
 import com.royware.corona.dashboard.model.data.world.WorldData;
 
 @Service
-public interface WorldDataServiceCaller {
+public interface IWorldDataServiceCaller {
 	public List<WorldData> getDataFromWorldSource();
 }

--- a/src/main/java/com/royware/corona/dashboard/interfaces/data/external/IExternalDataGetter.java
+++ b/src/main/java/com/royware/corona/dashboard/interfaces/data/external/IExternalDataGetter.java
@@ -4,8 +4,8 @@ import java.util.List;
 
 import com.royware.corona.dashboard.enums.regions.RegionsInDashboard;
 import com.royware.corona.dashboard.interfaces.data.IExternalDataConnectionService;
-import com.royware.corona.dashboard.interfaces.model.CanonicalCaseDeathData;
+import com.royware.corona.dashboard.interfaces.model.ICanonicalCaseDeathData;
 
 public interface IExternalDataGetter {
-	public <T extends CanonicalCaseDeathData> List<T> getDataUsing(IExternalDataConnectionService eds, RegionsInDashboard region);
+	public <T extends ICanonicalCaseDeathData> List<T> getDataUsing(IExternalDataConnectionService eds, RegionsInDashboard region);
 }

--- a/src/main/java/com/royware/corona/dashboard/interfaces/data/external/IExternalDataGetter.java
+++ b/src/main/java/com/royware/corona/dashboard/interfaces/data/external/IExternalDataGetter.java
@@ -1,0 +1,11 @@
+package com.royware.corona.dashboard.interfaces.data.external;
+
+import java.util.List;
+
+import com.royware.corona.dashboard.enums.regions.RegionsInDashboard;
+import com.royware.corona.dashboard.interfaces.data.IExternalDataConnectionService;
+import com.royware.corona.dashboard.interfaces.model.CanonicalCaseDeathData;
+
+public interface IExternalDataGetter {
+	public <T extends CanonicalCaseDeathData> List<T> getDataUsing(IExternalDataConnectionService eds, RegionsInDashboard region);
+}

--- a/src/main/java/com/royware/corona/dashboard/interfaces/data/external/IExternalDataGetterFactory.java
+++ b/src/main/java/com/royware/corona/dashboard/interfaces/data/external/IExternalDataGetterFactory.java
@@ -1,0 +1,10 @@
+package com.royware.corona.dashboard.interfaces.data.external;
+
+import org.springframework.stereotype.Service;
+
+import com.royware.corona.dashboard.enums.regions.RegionsInDashboard;
+
+@Service
+public interface IExternalDataGetterFactory {
+	public IExternalDataGetter create(RegionsInDashboard region);
+}

--- a/src/main/java/com/royware/corona/dashboard/interfaces/data/external/IExternalDataGetterStore.java
+++ b/src/main/java/com/royware/corona/dashboard/interfaces/data/external/IExternalDataGetterStore.java
@@ -1,0 +1,16 @@
+package com.royware.corona.dashboard.interfaces.data.external;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import com.royware.corona.dashboard.enums.regions.RegionsInDashboard;
+import com.royware.corona.dashboard.interfaces.data.IExternalDataConnectionService;
+import com.royware.corona.dashboard.interfaces.model.CanonicalCaseDeathData;
+
+@Service
+public interface IExternalDataGetterStore {
+	public <T extends CanonicalCaseDeathData> List<T> getDataFor(
+			RegionsInDashboard region,
+			IExternalDataConnectionService externalDataService);
+}

--- a/src/main/java/com/royware/corona/dashboard/interfaces/data/external/IExternalDataGetterStore.java
+++ b/src/main/java/com/royware/corona/dashboard/interfaces/data/external/IExternalDataGetterStore.java
@@ -6,11 +6,11 @@ import org.springframework.stereotype.Service;
 
 import com.royware.corona.dashboard.enums.regions.RegionsInDashboard;
 import com.royware.corona.dashboard.interfaces.data.IExternalDataConnectionService;
-import com.royware.corona.dashboard.interfaces.model.CanonicalCaseDeathData;
+import com.royware.corona.dashboard.interfaces.model.ICanonicalCaseDeathData;
 
 @Service
 public interface IExternalDataGetterStore {
-	public <T extends CanonicalCaseDeathData> List<T> getDataFor(
+	public <T extends ICanonicalCaseDeathData> List<T> getDataFor(
 			RegionsInDashboard region,
 			IExternalDataConnectionService externalDataService);
 }

--- a/src/main/java/com/royware/corona/dashboard/interfaces/data/external/IRegionDemographicDataGetterFactory.java
+++ b/src/main/java/com/royware/corona/dashboard/interfaces/data/external/IRegionDemographicDataGetterFactory.java
@@ -1,0 +1,11 @@
+package com.royware.corona.dashboard.interfaces.data.external;
+
+import org.springframework.stereotype.Service;
+
+import com.royware.corona.dashboard.enums.regions.RegionsInDashboard;
+import com.royware.corona.dashboard.model.data.common.RegionData;
+
+@Service
+public interface IRegionDemographicDataGetterFactory {
+	public RegionData getRegionDataFor(RegionsInDashboard region);
+}

--- a/src/main/java/com/royware/corona/dashboard/interfaces/data/external/IRegionDemographicDataGetterStore.java
+++ b/src/main/java/com/royware/corona/dashboard/interfaces/data/external/IRegionDemographicDataGetterStore.java
@@ -1,0 +1,11 @@
+package com.royware.corona.dashboard.interfaces.data.external;
+
+import org.springframework.stereotype.Service;
+
+import com.royware.corona.dashboard.enums.regions.RegionsInDashboard;
+
+@Service
+public interface IRegionDemographicDataGetterStore {
+	public String getRegionFullNameFor(RegionsInDashboard region);
+	public int getRegionPopulationFor(RegionsInDashboard region);
+}

--- a/src/main/java/com/royware/corona/dashboard/interfaces/model/ICanonicalCaseDeathData.java
+++ b/src/main/java/com/royware/corona/dashboard/interfaces/model/ICanonicalCaseDeathData.java
@@ -5,7 +5,7 @@ import java.time.LocalDate;
 import org.springframework.stereotype.Service;
 
 @Service
-public interface CanonicalCaseDeathData extends CanonicalHospitalData {
+public interface ICanonicalCaseDeathData extends ICanonicalHospitalData {
 	public int getDateInteger();
 	public LocalDate getDateChecked();
 	public int getTotalPositiveCases();

--- a/src/main/java/com/royware/corona/dashboard/interfaces/model/ICanonicalHospitalData.java
+++ b/src/main/java/com/royware/corona/dashboard/interfaces/model/ICanonicalHospitalData.java
@@ -1,6 +1,6 @@
 package com.royware.corona.dashboard.interfaces.model;
 
-public interface CanonicalHospitalData extends CanonicalVaccinationData {
+public interface ICanonicalHospitalData extends ICanonicalVaccinationData {
 	public int getHospitalizedCurrently();
 	public void setHospitalizedCurrently(int hospitalizedCurrently);
 	public int getHospitalizedCumulative();

--- a/src/main/java/com/royware/corona/dashboard/interfaces/model/ICanonicalVaccinationData.java
+++ b/src/main/java/com/royware/corona/dashboard/interfaces/model/ICanonicalVaccinationData.java
@@ -1,6 +1,6 @@
 package com.royware.corona.dashboard.interfaces.model;
 
-public interface CanonicalVaccinationData {
+public interface ICanonicalVaccinationData {
 	public int getTotalVaccCompleted();
 	public void setTotalVaccCompleted(int totalVaccCompleted);
 }

--- a/src/main/java/com/royware/corona/dashboard/model/data/us/UnitedStatesData.java
+++ b/src/main/java/com/royware/corona/dashboard/model/data/us/UnitedStatesData.java
@@ -2,11 +2,11 @@ package com.royware.corona.dashboard.model.data.us;
 
 import java.time.LocalDate;
 
-import com.royware.corona.dashboard.interfaces.model.CanonicalCaseDeathData;
-import com.royware.corona.dashboard.interfaces.model.CanonicalHospitalData;
-import com.royware.corona.dashboard.interfaces.model.CanonicalVaccinationData;
+import com.royware.corona.dashboard.interfaces.model.ICanonicalCaseDeathData;
+import com.royware.corona.dashboard.interfaces.model.ICanonicalHospitalData;
+import com.royware.corona.dashboard.interfaces.model.ICanonicalVaccinationData;
 
-public class UnitedStatesData implements CanonicalCaseDeathData, CanonicalHospitalData, CanonicalVaccinationData {
+public class UnitedStatesData implements ICanonicalCaseDeathData, ICanonicalHospitalData, ICanonicalVaccinationData {
 	private int dateInteger;
 	private String dateTimeString;
 	private int totalPositiveCases;

--- a/src/main/java/com/royware/corona/dashboard/model/data/world/WorldData.java
+++ b/src/main/java/com/royware/corona/dashboard/model/data/world/WorldData.java
@@ -4,10 +4,10 @@ import java.time.LocalDate;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.royware.corona.dashboard.interfaces.model.CanonicalCaseDeathData;
+import com.royware.corona.dashboard.interfaces.model.ICanonicalCaseDeathData;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class WorldData implements CanonicalCaseDeathData {
+public class WorldData implements ICanonicalCaseDeathData {
 	@JsonProperty("dateRep") private String stringDate;
 	@JsonProperty("year") private int year;
 	@JsonProperty("month") private int month;

--- a/src/main/java/com/royware/corona/dashboard/services/chart/list/factory/ChartListStore.java
+++ b/src/main/java/com/royware/corona/dashboard/services/chart/list/factory/ChartListStore.java
@@ -9,7 +9,7 @@ import org.springframework.stereotype.Component;
 import com.royware.corona.dashboard.enums.charts.ChartTypes;
 import com.royware.corona.dashboard.interfaces.chartlist.IChartListFactory;
 import com.royware.corona.dashboard.interfaces.chartlist.IChartListStore;
-import com.royware.corona.dashboard.interfaces.model.CanonicalCaseDeathData;
+import com.royware.corona.dashboard.interfaces.model.ICanonicalCaseDeathData;
 
 @Component
 public class ChartListStore implements IChartListStore {
@@ -17,7 +17,7 @@ public class ChartListStore implements IChartListStore {
 	private IChartListFactory chartListFactory;
 	
 	@Override
-	public <T extends CanonicalCaseDeathData> List<List<Map<Object, Object>>> produceChartListFromRegionData(
+	public <T extends ICanonicalCaseDeathData> List<List<Map<Object, Object>>> produceChartListFromRegionData(
 			ChartTypes chartType,
 			List<T> regionData,
 			int regionPopulation) {

--- a/src/main/java/com/royware/corona/dashboard/services/chart/list/makers/ChangeInTotalCasesVersusCasesWithExponentialLineChartList.java
+++ b/src/main/java/com/royware/corona/dashboard/services/chart/list/makers/ChangeInTotalCasesVersusCasesWithExponentialLineChartList.java
@@ -10,7 +10,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 import com.royware.corona.dashboard.interfaces.chartlist.IChartListMaker;
-import com.royware.corona.dashboard.interfaces.model.CanonicalCaseDeathData;
+import com.royware.corona.dashboard.interfaces.model.ICanonicalCaseDeathData;
 
 @Component
 public class ChangeInTotalCasesVersusCasesWithExponentialLineChartList implements IChartListMaker {
@@ -18,7 +18,7 @@ public class ChangeInTotalCasesVersusCasesWithExponentialLineChartList implement
 	private Map<Integer, Double> dailyChgCases = new HashMap<>();
 
 	@Override
-	public <T extends CanonicalCaseDeathData> List<List<Map<Object, Object>>> makeListFrom(List<T> regionDataList, int pop) {
+	public <T extends ICanonicalCaseDeathData> List<List<Map<Object, Object>>> makeListFrom(List<T> regionDataList, int pop) {
 		log.debug("MAKING CHANGE IN DAILY CASES VERSUS TOTAL CASES");
 		//Transform the data into ChartJS-ready lists
 		Map<Object, Object> xyPair;

--- a/src/main/java/com/royware/corona/dashboard/services/chart/list/makers/ChangeInTotalDeathsVersusDeathsWithExponentialLineChartList.java
+++ b/src/main/java/com/royware/corona/dashboard/services/chart/list/makers/ChangeInTotalDeathsVersusDeathsWithExponentialLineChartList.java
@@ -11,7 +11,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 import com.royware.corona.dashboard.interfaces.chartlist.IChartListMaker;
-import com.royware.corona.dashboard.interfaces.model.CanonicalCaseDeathData;
+import com.royware.corona.dashboard.interfaces.model.ICanonicalCaseDeathData;
 
 @Component
 public class ChangeInTotalDeathsVersusDeathsWithExponentialLineChartList implements IChartListMaker {
@@ -19,7 +19,7 @@ public class ChangeInTotalDeathsVersusDeathsWithExponentialLineChartList impleme
 	private Map<Integer, Double> dailyChgDeaths = new LinkedHashMap<>();
 
 	@Override
-	public <T extends CanonicalCaseDeathData> List<List<Map<Object, Object>>> makeListFrom(List<T> regionDataList, int pop) {
+	public <T extends ICanonicalCaseDeathData> List<List<Map<Object, Object>>> makeListFrom(List<T> regionDataList, int pop) {
 		log.debug("MAKING CHANGE IN DAILY DEATHS VERSUS TOTAL DEATHS");
 		//Transform the data into ChartJS-ready lists
 		Map<Object, Object> xyPair;

--- a/src/main/java/com/royware/corona/dashboard/services/chart/list/makers/ChartListMakerUtilities.java
+++ b/src/main/java/com/royware/corona/dashboard/services/chart/list/makers/ChartListMakerUtilities.java
@@ -9,7 +9,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.royware.corona.dashboard.enums.data.MovingAverageSizes;
-import com.royware.corona.dashboard.interfaces.model.CanonicalCaseDeathData;
+import com.royware.corona.dashboard.interfaces.model.ICanonicalCaseDeathData;
 
 public class ChartListMakerUtilities {
 	private static final Logger log = LoggerFactory.getLogger(ChartListMakerUtilities.class);
@@ -23,7 +23,7 @@ public class ChartListMakerUtilities {
 		return xyPair;
 	}
 
-	public static <T extends CanonicalCaseDeathData> int findFirstDayIndexWithPositiveDeaths(List<T> regionDataList) {
+	public static <T extends ICanonicalCaseDeathData> int findFirstDayIndexWithPositiveDeaths(List<T> regionDataList) {
 		for(int dayIndex = 0; dayIndex < regionDataList.size(); dayIndex++) {
 			if(regionDataList.get(dayIndex).getTotalDeaths() > 0) {
 				log.debug("first day index with positive deaths: " + dayIndex
@@ -34,7 +34,7 @@ public class ChartListMakerUtilities {
 		return 0;
 	}
 	
-	public static <T extends CanonicalCaseDeathData> int findFirstDayIndexWithPositiveCurrentHospitalizations(List<T> regionDataList) {
+	public static <T extends ICanonicalCaseDeathData> int findFirstDayIndexWithPositiveCurrentHospitalizations(List<T> regionDataList) {
 		for(int dayIndex = 0; dayIndex < regionDataList.size(); dayIndex++) {
 			if(regionDataList.get(dayIndex).getHospitalizedCurrently() > 0) {
 				log.debug("first day index with positive current hospitalizations: " + dayIndex
@@ -45,7 +45,7 @@ public class ChartListMakerUtilities {
 		return 0;
 	}
 	
-	public static <T extends CanonicalCaseDeathData> int findFirstDayIndexWithPositiveCumulativeHospitalizations(List<T> regionDataList) {
+	public static <T extends ICanonicalCaseDeathData> int findFirstDayIndexWithPositiveCumulativeHospitalizations(List<T> regionDataList) {
 		for(int dayIndex = 0; dayIndex < regionDataList.size(); dayIndex++) {
 			if(regionDataList.get(dayIndex).getHospitalizedCumulative() > 0) {
 				log.debug("first day index with positive cumulative hospitalizations: " + dayIndex

--- a/src/main/java/com/royware/corona/dashboard/services/chart/list/makers/CurrentTotalDeathsWithPercentOfPopulationChartList.java
+++ b/src/main/java/com/royware/corona/dashboard/services/chart/list/makers/CurrentTotalDeathsWithPercentOfPopulationChartList.java
@@ -13,14 +13,14 @@ import org.springframework.stereotype.Component;
 
 import com.royware.corona.dashboard.enums.data.MovingAverageSizes;
 import com.royware.corona.dashboard.interfaces.chartlist.IChartListMaker;
-import com.royware.corona.dashboard.interfaces.model.CanonicalCaseDeathData;
+import com.royware.corona.dashboard.interfaces.model.ICanonicalCaseDeathData;
 
 @Component
 public class CurrentTotalDeathsWithPercentOfPopulationChartList implements IChartListMaker {
 	private static final Logger log = LoggerFactory.getLogger(CurrentTotalDeathsWithPercentOfPopulationChartList.class);
 
 	@Override
-	public <T extends CanonicalCaseDeathData> List<List<Map<Object, Object>>> makeListFrom(List<T> regionDataList, int regionPopulation) {
+	public <T extends ICanonicalCaseDeathData> List<List<Map<Object, Object>>> makeListFrom(List<T> regionDataList, int regionPopulation) {
 		log.debug("MAKING CURRENT TOTAL DEATHS VERSUS TIME");
 		//Transform the data into ChartJS-ready lists
 		Map<Object, Object> xyPair;

--- a/src/main/java/com/royware/corona/dashboard/services/chart/list/makers/CurrentTotalPositivesWithPercentOfPopulationChartList.java
+++ b/src/main/java/com/royware/corona/dashboard/services/chart/list/makers/CurrentTotalPositivesWithPercentOfPopulationChartList.java
@@ -13,14 +13,14 @@ import org.springframework.stereotype.Component;
 
 import com.royware.corona.dashboard.enums.data.MovingAverageSizes;
 import com.royware.corona.dashboard.interfaces.chartlist.IChartListMaker;
-import com.royware.corona.dashboard.interfaces.model.CanonicalCaseDeathData;
+import com.royware.corona.dashboard.interfaces.model.ICanonicalCaseDeathData;
 
 @Component
 public class CurrentTotalPositivesWithPercentOfPopulationChartList implements IChartListMaker {
 	private static final Logger log = LoggerFactory.getLogger(CurrentTotalPositivesWithPercentOfPopulationChartList.class);
 	
 	@Override
-	public <T extends CanonicalCaseDeathData> List<List<Map<Object, Object>>> makeListFrom(List<T> regionDataList, int regionPopulation) {
+	public <T extends ICanonicalCaseDeathData> List<List<Map<Object, Object>>> makeListFrom(List<T> regionDataList, int regionPopulation) {
 		log.debug("MAKING CURRENT TOTAL POSITIVES VERSUS TIME");
 		//Transform the data into ChartJS-ready lists
 		Map<Object, Object> xyPair;

--- a/src/main/java/com/royware/corona/dashboard/services/chart/list/makers/DailyAccelerationOfCasesWithMovingAverageChartList.java
+++ b/src/main/java/com/royware/corona/dashboard/services/chart/list/makers/DailyAccelerationOfCasesWithMovingAverageChartList.java
@@ -11,14 +11,14 @@ import org.springframework.stereotype.Component;
 
 import com.royware.corona.dashboard.enums.data.MovingAverageSizes;
 import com.royware.corona.dashboard.interfaces.chartlist.IChartListMaker;
-import com.royware.corona.dashboard.interfaces.model.CanonicalCaseDeathData;
+import com.royware.corona.dashboard.interfaces.model.ICanonicalCaseDeathData;
 
 @Component
 public class DailyAccelerationOfCasesWithMovingAverageChartList implements IChartListMaker {
 	private static final Logger log = LoggerFactory.getLogger(DailyAccelerationOfCasesWithMovingAverageChartList.class);
 
 	@Override
-	public <T extends CanonicalCaseDeathData> List<List<Map<Object, Object>>> makeListFrom(List<T> regionDataList, int pop) {
+	public <T extends ICanonicalCaseDeathData> List<List<Map<Object, Object>>> makeListFrom(List<T> regionDataList, int pop) {
 		log.debug("MAKING ACCELERATION OF DAILY CASES VERSUS TIME");
 		//Transform the data into ChartJS-ready lists
 		Map<Object, Object> xyPair;

--- a/src/main/java/com/royware/corona/dashboard/services/chart/list/makers/DailyAccelerationOfDeathsWithMovingAverageChartList.java
+++ b/src/main/java/com/royware/corona/dashboard/services/chart/list/makers/DailyAccelerationOfDeathsWithMovingAverageChartList.java
@@ -11,14 +11,14 @@ import org.springframework.stereotype.Component;
 
 import com.royware.corona.dashboard.enums.data.MovingAverageSizes;
 import com.royware.corona.dashboard.interfaces.chartlist.IChartListMaker;
-import com.royware.corona.dashboard.interfaces.model.CanonicalCaseDeathData;
+import com.royware.corona.dashboard.interfaces.model.ICanonicalCaseDeathData;
 
 @Component
 public class DailyAccelerationOfDeathsWithMovingAverageChartList implements IChartListMaker {
 	private static final Logger log = LoggerFactory.getLogger(DailyAccelerationOfDeathsWithMovingAverageChartList.class);
 
 	@Override
-	public <T extends CanonicalCaseDeathData> List<List<Map<Object, Object>>> makeListFrom(List<T> regionDataList, int pop) {
+	public <T extends ICanonicalCaseDeathData> List<List<Map<Object, Object>>> makeListFrom(List<T> regionDataList, int pop) {
 		log.debug("MAKING ACCELERATION OF DAILY DEATHS VERSUS TIME");
 		//Transform the data into ChartJS-ready lists
 		Map<Object, Object> xyPair;

--- a/src/main/java/com/royware/corona/dashboard/services/chart/list/makers/DailyAndTotalCasesVersusTimeChartList.java
+++ b/src/main/java/com/royware/corona/dashboard/services/chart/list/makers/DailyAndTotalCasesVersusTimeChartList.java
@@ -11,7 +11,7 @@ import org.springframework.stereotype.Component;
 
 import com.royware.corona.dashboard.enums.data.MovingAverageSizes;
 import com.royware.corona.dashboard.interfaces.chartlist.IChartListMaker;
-import com.royware.corona.dashboard.interfaces.model.CanonicalCaseDeathData;
+import com.royware.corona.dashboard.interfaces.model.ICanonicalCaseDeathData;
 
 @Component
 public class DailyAndTotalCasesVersusTimeChartList implements IChartListMaker {
@@ -19,7 +19,7 @@ public class DailyAndTotalCasesVersusTimeChartList implements IChartListMaker {
 	private Map<Integer, Double> dailyNewCases = new HashMap<>();
 
 	@Override
-	public <T extends CanonicalCaseDeathData> List<List<Map<Object, Object>>> makeListFrom(List<T> regionDataList, int pop) {
+	public <T extends ICanonicalCaseDeathData> List<List<Map<Object, Object>>> makeListFrom(List<T> regionDataList, int pop) {
 		log.debug("MAKING TOTAL AND DAILY CASES VERSUS TIME");
 		//Transform the data into ChartJS-ready lists
 		Map<Object, Object> xyPair;

--- a/src/main/java/com/royware/corona/dashboard/services/chart/list/makers/DailyHospitalizedNowWithMovingAverageChartList.java
+++ b/src/main/java/com/royware/corona/dashboard/services/chart/list/makers/DailyHospitalizedNowWithMovingAverageChartList.java
@@ -11,7 +11,7 @@ import org.springframework.stereotype.Component;
 
 import com.royware.corona.dashboard.enums.data.MovingAverageSizes;
 import com.royware.corona.dashboard.interfaces.chartlist.IChartListMaker;
-import com.royware.corona.dashboard.interfaces.model.CanonicalCaseDeathData;
+import com.royware.corona.dashboard.interfaces.model.ICanonicalCaseDeathData;
 
 @Component
 public class DailyHospitalizedNowWithMovingAverageChartList implements IChartListMaker {
@@ -19,7 +19,7 @@ public class DailyHospitalizedNowWithMovingAverageChartList implements IChartLis
 	private Map<Integer, Double> dailyHospitalizations = new HashMap<>();
 
 	@Override
-	public <T extends CanonicalCaseDeathData> List<List<Map<Object, Object>>> makeListFrom(List<T> regionDataList, int pop) {
+	public <T extends ICanonicalCaseDeathData> List<List<Map<Object, Object>>> makeListFrom(List<T> regionDataList, int pop) {
 		log.debug("MAKING CURRENT AND DAILY NEW HOSPITALIZATIONS VERSUS TIME");
 		//Transform the data into ChartJS-ready lists
 		Map<Object, Object> xyPair;

--- a/src/main/java/com/royware/corona/dashboard/services/chart/list/makers/DailyHospitalizedTotalWithMovingAverageChartList.java
+++ b/src/main/java/com/royware/corona/dashboard/services/chart/list/makers/DailyHospitalizedTotalWithMovingAverageChartList.java
@@ -11,7 +11,7 @@ import org.springframework.stereotype.Component;
 
 import com.royware.corona.dashboard.enums.data.MovingAverageSizes;
 import com.royware.corona.dashboard.interfaces.chartlist.IChartListMaker;
-import com.royware.corona.dashboard.interfaces.model.CanonicalCaseDeathData;
+import com.royware.corona.dashboard.interfaces.model.ICanonicalCaseDeathData;
 
 @Component
 public class DailyHospitalizedTotalWithMovingAverageChartList implements IChartListMaker {
@@ -19,7 +19,7 @@ public class DailyHospitalizedTotalWithMovingAverageChartList implements IChartL
 	private Map<Integer, Double> cumulHospitalizations = new HashMap<>();
 
 	@Override
-	public <T extends CanonicalCaseDeathData> List<List<Map<Object, Object>>> makeListFrom(List<T> regionDataList, int pop) {
+	public <T extends ICanonicalCaseDeathData> List<List<Map<Object, Object>>> makeListFrom(List<T> regionDataList, int pop) {
 		log.debug("MAKING CUMULATIVE AND DAILY NEW HOSPITALIZATIONS (FROM CUMULATIVE) VERSUS TIME");
 		//Transform the data into ChartJS-ready lists
 		Map<Object, Object> xyPair;

--- a/src/main/java/com/royware/corona/dashboard/services/chart/list/makers/DailyRateOfChangeOfCasesWithMovingAverageChartList.java
+++ b/src/main/java/com/royware/corona/dashboard/services/chart/list/makers/DailyRateOfChangeOfCasesWithMovingAverageChartList.java
@@ -11,7 +11,7 @@ import org.springframework.stereotype.Component;
 
 import com.royware.corona.dashboard.enums.data.MovingAverageSizes;
 import com.royware.corona.dashboard.interfaces.chartlist.IChartListMaker;
-import com.royware.corona.dashboard.interfaces.model.CanonicalCaseDeathData;
+import com.royware.corona.dashboard.interfaces.model.ICanonicalCaseDeathData;
 
 @Component
 public class DailyRateOfChangeOfCasesWithMovingAverageChartList implements IChartListMaker {
@@ -19,7 +19,7 @@ public class DailyRateOfChangeOfCasesWithMovingAverageChartList implements IChar
 	private Map<Integer, Double> dailyPctChgCases = new HashMap<>();
 
 	@Override
-	public <T extends CanonicalCaseDeathData> List<List<Map<Object, Object>>> makeListFrom(List<T> regionDataList, int pop) {
+	public <T extends ICanonicalCaseDeathData> List<List<Map<Object, Object>>> makeListFrom(List<T> regionDataList, int pop) {
 		log.debug("MAKING RATE OF CHANGE OF DAILY CASES VERSUS TIME");
 		//Transform the data into ChartJS-ready lists
 		Map<Object, Object> xyPair;

--- a/src/main/java/com/royware/corona/dashboard/services/chart/list/makers/DailyRateOfChangeOfDeathsWithMovingAverageChartList.java
+++ b/src/main/java/com/royware/corona/dashboard/services/chart/list/makers/DailyRateOfChangeOfDeathsWithMovingAverageChartList.java
@@ -12,7 +12,7 @@ import org.springframework.stereotype.Component;
 
 import com.royware.corona.dashboard.enums.data.MovingAverageSizes;
 import com.royware.corona.dashboard.interfaces.chartlist.IChartListMaker;
-import com.royware.corona.dashboard.interfaces.model.CanonicalCaseDeathData;
+import com.royware.corona.dashboard.interfaces.model.ICanonicalCaseDeathData;
 
 @Component
 public class DailyRateOfChangeOfDeathsWithMovingAverageChartList implements IChartListMaker {
@@ -20,7 +20,7 @@ public class DailyRateOfChangeOfDeathsWithMovingAverageChartList implements ICha
 	private Map<Integer, Double> dailyPctChgDeaths = new LinkedHashMap<>();
 
 	@Override
-	public <T extends CanonicalCaseDeathData> List<List<Map<Object, Object>>> makeListFrom(List<T> regionDataList, int pop) {
+	public <T extends ICanonicalCaseDeathData> List<List<Map<Object, Object>>> makeListFrom(List<T> regionDataList, int pop) {
 		log.debug("MAKING RATE OF CHANGE OF DAILY DEATHS VERSUS TIME");
 		//Transform the data into ChartJS-ready lists
 		Map<Object, Object> xyPair;

--- a/src/main/java/com/royware/corona/dashboard/services/chart/list/makers/DailyRatioCasesToTestsWithMovingAverageChartList.java
+++ b/src/main/java/com/royware/corona/dashboard/services/chart/list/makers/DailyRatioCasesToTestsWithMovingAverageChartList.java
@@ -11,7 +11,7 @@ import org.springframework.stereotype.Component;
 
 import com.royware.corona.dashboard.enums.data.MovingAverageSizes;
 import com.royware.corona.dashboard.interfaces.chartlist.IChartListMaker;
-import com.royware.corona.dashboard.interfaces.model.CanonicalCaseDeathData;
+import com.royware.corona.dashboard.interfaces.model.ICanonicalCaseDeathData;
 
 @Component
 public class DailyRatioCasesToTestsWithMovingAverageChartList implements IChartListMaker {
@@ -19,7 +19,7 @@ public class DailyRatioCasesToTestsWithMovingAverageChartList implements IChartL
 	private Map<Integer, Double> dailyRatioOfTests = new HashMap<>();
 
 	@Override
-	public <T extends CanonicalCaseDeathData> List<List<Map<Object, Object>>> makeListFrom(List<T> regionDataList, int pop) {
+	public <T extends ICanonicalCaseDeathData> List<List<Map<Object, Object>>> makeListFrom(List<T> regionDataList, int pop) {
 		log.debug("MAKING RATIO OF CASES TO TESTS VERSUS TIME");
 		//Transform the data into ChartJS-ready lists
 		Map<Object, Object> xyPair;

--- a/src/main/java/com/royware/corona/dashboard/services/chart/list/makers/DailyTestsTotalTestsVersusTimeChartList.java
+++ b/src/main/java/com/royware/corona/dashboard/services/chart/list/makers/DailyTestsTotalTestsVersusTimeChartList.java
@@ -11,7 +11,7 @@ import org.springframework.stereotype.Component;
 
 import com.royware.corona.dashboard.enums.data.MovingAverageSizes;
 import com.royware.corona.dashboard.interfaces.chartlist.IChartListMaker;
-import com.royware.corona.dashboard.interfaces.model.CanonicalCaseDeathData;
+import com.royware.corona.dashboard.interfaces.model.ICanonicalCaseDeathData;
 
 @Component
 public class DailyTestsTotalTestsVersusTimeChartList implements IChartListMaker {
@@ -19,7 +19,7 @@ public class DailyTestsTotalTestsVersusTimeChartList implements IChartListMaker 
 	private Map<Integer, Double> dailyTests = new HashMap<>();
 
 	@Override
-	public <T extends CanonicalCaseDeathData> List<List<Map<Object, Object>>> makeListFrom(List<T> regionDataList, int pop) {
+	public <T extends ICanonicalCaseDeathData> List<List<Map<Object, Object>>> makeListFrom(List<T> regionDataList, int pop) {
 		log.debug("MAKING TOTAL AND DAILY TESTS VERSUS TIME");
 		//Transform the data into ChartJS-ready lists
 		Map<Object, Object> xyPair;

--- a/src/main/java/com/royware/corona/dashboard/services/chart/list/makers/DailyVaccTotalVaccVersusTimeChartList.java
+++ b/src/main/java/com/royware/corona/dashboard/services/chart/list/makers/DailyVaccTotalVaccVersusTimeChartList.java
@@ -11,7 +11,7 @@ import org.springframework.stereotype.Component;
 
 import com.royware.corona.dashboard.enums.data.MovingAverageSizes;
 import com.royware.corona.dashboard.interfaces.chartlist.IChartListMaker;
-import com.royware.corona.dashboard.interfaces.model.CanonicalCaseDeathData;
+import com.royware.corona.dashboard.interfaces.model.ICanonicalCaseDeathData;
 
 @Component
 public class DailyVaccTotalVaccVersusTimeChartList implements IChartListMaker {
@@ -19,7 +19,7 @@ public class DailyVaccTotalVaccVersusTimeChartList implements IChartListMaker {
 	private Map<Integer, Double> dailyVacc = new HashMap<>();
 
 	@Override
-	public <T extends CanonicalCaseDeathData> List<List<Map<Object, Object>>> makeListFrom(List<T> regionDataList, int pop) {
+	public <T extends ICanonicalCaseDeathData> List<List<Map<Object, Object>>> makeListFrom(List<T> regionDataList, int pop) {
 		log.debug("MAKING TOTAL AND DAILY VACCINATIONS VERSUS TIME");
 		//Transform the data into ChartJS-ready lists
 		Map<Object, Object> xyPair;

--- a/src/main/java/com/royware/corona/dashboard/services/chart/list/makers/TotalDeathsVersusTimeWithExponentialFitChartList.java
+++ b/src/main/java/com/royware/corona/dashboard/services/chart/list/makers/TotalDeathsVersusTimeWithExponentialFitChartList.java
@@ -11,7 +11,7 @@ import org.springframework.stereotype.Component;
 
 import com.royware.corona.dashboard.enums.data.MovingAverageSizes;
 import com.royware.corona.dashboard.interfaces.chartlist.IChartListMaker;
-import com.royware.corona.dashboard.interfaces.model.CanonicalCaseDeathData;
+import com.royware.corona.dashboard.interfaces.model.ICanonicalCaseDeathData;
 
 @Component
 public class TotalDeathsVersusTimeWithExponentialFitChartList implements IChartListMaker {
@@ -19,7 +19,7 @@ public class TotalDeathsVersusTimeWithExponentialFitChartList implements IChartL
 	private Map<Integer, Double> dailyDeaths = new HashMap<>();
 
 	@Override
-	public <T extends CanonicalCaseDeathData> List<List<Map<Object, Object>>> makeListFrom(List<T> regionDataList, int pop) {
+	public <T extends ICanonicalCaseDeathData> List<List<Map<Object, Object>>> makeListFrom(List<T> regionDataList, int pop) {
 		log.debug("MAKING TOTAL AND DAILY DEATHS VERSUS TIME");
 		//Transform the data into ChartJS-ready lists
 		Map<Object, Object> xyPair;

--- a/src/main/java/com/royware/corona/dashboard/services/dashboard/DashboardChartServiceImpl.java
+++ b/src/main/java/com/royware/corona/dashboard/services/dashboard/DashboardChartServiceImpl.java
@@ -14,16 +14,16 @@ import com.royware.corona.dashboard.enums.charts.ChartTypes;
 import com.royware.corona.dashboard.enums.dashstats.DashStatsTypes;
 import com.royware.corona.dashboard.interfaces.chartconfig.IChartConfigStore;
 import com.royware.corona.dashboard.interfaces.chartlist.IChartListStore;
-import com.royware.corona.dashboard.interfaces.dashboard.DashboardChartService;
+import com.royware.corona.dashboard.interfaces.dashboard.IDashboardChartService;
 import com.royware.corona.dashboard.interfaces.dashboard.IDashStatsStore;
-import com.royware.corona.dashboard.interfaces.model.CanonicalCaseDeathData;
+import com.royware.corona.dashboard.interfaces.model.ICanonicalCaseDeathData;
 import com.royware.corona.dashboard.model.dashboard.DashboardChart;
 import com.royware.corona.dashboard.model.dashboard.DashboardChartConfig;
 import com.royware.corona.dashboard.model.dashboard.DashboardChartData;
 import com.royware.corona.dashboard.model.dashboard.DashboardStatistics;
 
 @Component
-public class DashboardChartServiceImpl implements DashboardChartService {
+public class DashboardChartServiceImpl implements IDashboardChartService {
 	@Autowired private IChartListStore chartListStore;
 	@Autowired private IChartConfigStore chartConfigStore;
 	@Autowired private IDashStatsStore dashStatsStore;
@@ -31,7 +31,7 @@ public class DashboardChartServiceImpl implements DashboardChartService {
 	private static final Logger log = LoggerFactory.getLogger(DashboardChartServiceImpl.class);
 	
 	@Override
-	public <T extends CanonicalCaseDeathData> List<DashboardChart> makeAllDashboardChartsAndStats(
+	public <T extends ICanonicalCaseDeathData> List<DashboardChart> makeAllDashboardChartsAndStats(
 			List<T> dataList, String region, Integer regionPopulation, DashboardStatistics dashStats) {
 		
 		List<DashboardChart> dashboardList = new ArrayList<>();

--- a/src/main/java/com/royware/corona/dashboard/services/dashboard/DashboardConfigServiceImpl.java
+++ b/src/main/java/com/royware/corona/dashboard/services/dashboard/DashboardConfigServiceImpl.java
@@ -12,12 +12,16 @@ import org.springframework.ui.ModelMap;
 import com.royware.corona.dashboard.enums.dashstats.DashStatsTypes;
 import com.royware.corona.dashboard.enums.data.MovingAverageSizes;
 import com.royware.corona.dashboard.enums.regions.RegionsData;
+import com.royware.corona.dashboard.enums.regions.RegionsInDashboard;
 import com.royware.corona.dashboard.interfaces.dashboard.DashboardChartService;
 import com.royware.corona.dashboard.interfaces.dashboard.DashboardConfigService;
 import com.royware.corona.dashboard.interfaces.dashboard.IDashStatsStore;
-import com.royware.corona.dashboard.interfaces.data.ExternalDataService;
+import com.royware.corona.dashboard.interfaces.data.IExternalDataConnectionService;
 import com.royware.corona.dashboard.interfaces.data.ExternalDataServiceFactory;
 import com.royware.corona.dashboard.interfaces.data.IMultiRegionExternalDataService;
+import com.royware.corona.dashboard.interfaces.data.external.IExternalDataGetterStore;
+import com.royware.corona.dashboard.interfaces.data.external.IRegionDemographicDataGetterFactory;
+import com.royware.corona.dashboard.interfaces.data.external.IRegionDemographicDataGetterStore;
 import com.royware.corona.dashboard.interfaces.model.CanonicalCaseDeathData;
 import com.royware.corona.dashboard.model.dashboard.DashboardHeader;
 import com.royware.corona.dashboard.model.dashboard.DashboardMeta;
@@ -33,6 +37,8 @@ public class DashboardConfigServiceImpl implements DashboardConfigService {
 	@Autowired private DashboardStatistics dashStats;
 	@Autowired private DashboardChartService dashboardChartService;
 	@Autowired private IMultiRegionExternalDataService dashboardMultiRegionService;
+	@Autowired private IRegionDemographicDataGetterStore regionDemoDataStore;
+	@Autowired private IExternalDataGetterStore externalDataGetterStore;
 	
 	private static final Logger log = LoggerFactory.getLogger(DashboardConfigServiceImpl.class);
 	
@@ -45,7 +51,7 @@ public class DashboardConfigServiceImpl implements DashboardConfigService {
 		final int MAX_REGION_LENGTH_TO_DISPLAY = 28;
 		
 		//Check for null data service or an empty multi-region
-		ExternalDataService dataService = getExternalDataServiceFromFactory(rawRegionString);
+		IExternalDataConnectionService dataService = getExternalDataServiceFromFactory(rawRegionString);
 		if(dataService == null || (isMultiRegion && rawRegionString.substring(6).length() < 2)) {
 			log.error("In populateDashboardModelMap: Unable to getExternalDataServiceFromFactory");
 			return false;
@@ -60,9 +66,14 @@ public class DashboardConfigServiceImpl implements DashboardConfigService {
 			regionPopulation = dashboardMultiRegionService.getMultiRegionPopulation(regionsOnlyCsvString);
 			dataList = dashboardMultiRegionService.getMultiRegionDataFromExternalSource(regionsOnlyCsvString, dataService);
 		} else {
-			fullRegionString = RegionsData.valueOf(rawRegionString).getRegionData().getFullName();
-			regionPopulation = RegionsData.valueOf(rawRegionString).getRegionData().getPopulation();
-			dataList = RegionsData.valueOf(rawRegionString).getCoronaVirusDataFromExternalSource(dataService);
+			RegionsInDashboard region = RegionsInDashboard.valueOfLabel(rawRegionString);
+			fullRegionString = regionDemoDataStore.getRegionFullNameFor(region);
+			regionPopulation = regionDemoDataStore.getRegionPopulationFor(region);
+			dataList = externalDataGetterStore.getDataFor(region, dataService);
+			
+//			fullRegionString = RegionsData.valueOf(rawRegionString).getRegionData().getFullName();
+//			regionPopulation = RegionsData.valueOf(rawRegionString).getRegionData().getPopulation();
+//			dataList = RegionsData.valueOf(rawRegionString).getCoronaVirusDataFromExternalSource(dataService);
 		}
 		log.debug("fullRegionString: " + fullRegionString + ", regionPopulation: " + regionPopulation + ", dataList size: " + dataList.size());
 		log.info("Finished making the data list...");
@@ -112,9 +123,9 @@ public class DashboardConfigServiceImpl implements DashboardConfigService {
 		return true;
 	}
 
-	private ExternalDataService getExternalDataServiceFromFactory(String region) {
+	private IExternalDataConnectionService getExternalDataServiceFromFactory(String region) {
 		try {
-			ExternalDataService dataService = dataFactory.getExternalDataService(region);
+			IExternalDataConnectionService dataService = dataFactory.getExternalDataService(region);
 			log.debug("Success, got the dataService: " + dataService.toString());
 			return dataService;
 		} catch (IllegalArgumentException e) {

--- a/src/main/java/com/royware/corona/dashboard/services/dashboard/DashboardConfigServiceImpl.java
+++ b/src/main/java/com/royware/corona/dashboard/services/dashboard/DashboardConfigServiceImpl.java
@@ -64,7 +64,7 @@ public class DashboardConfigServiceImpl implements IDashboardConfigService {
 			regionPopulation = dashboardMultiRegionService.getMultiRegionPopulation(regionsOnlyCsvString);
 			dataList = dashboardMultiRegionService.getMultiRegionDataFromExternalSource(regionsOnlyCsvString, dataService);
 		} else {
-			RegionsInDashboard region = RegionsInDashboard.valueOfLabel(rawRegionString);
+			RegionsInDashboard region = RegionsInDashboard.valueOfEnum(rawRegionString);
 			fullRegionString = regionDemoDataStore.getRegionFullNameFor(region);
 			regionPopulation = regionDemoDataStore.getRegionPopulationFor(region);
 			dataList = externalDataGetterStore.getDataFor(region, dataService);
@@ -98,7 +98,8 @@ public class DashboardConfigServiceImpl implements IDashboardConfigService {
 			log.info("Making all the DASHBOARD STATISTICS FOR REGION - BY U.S. TOTALS");
 			log.debug("Getting U.S. data for populating By U.S. Totals row of dashboard...");
 			
-			List<UnitedStatesData> usaData = externalDataGetterStore.getDataFor(RegionsInDashboard.USA, dataService);
+			List<UnitedStatesData> usaData = externalDataGetterStore.getDataFor(RegionsInDashboard.USA,
+					getExternalDataServiceFromFactory(RegionsInDashboard.USA.name()));
 
 //			List<UnitedStatesData> usaData = RegionsData.USA
 //				.getCoronaVirusDataFromExternalSource(getExternalDataServiceFromFactory(RegionsData.USA.name()));

--- a/src/main/java/com/royware/corona/dashboard/services/dashboard/DashboardConfigServiceImpl.java
+++ b/src/main/java/com/royware/corona/dashboard/services/dashboard/DashboardConfigServiceImpl.java
@@ -11,7 +11,6 @@ import org.springframework.ui.ModelMap;
 
 import com.royware.corona.dashboard.enums.dashstats.DashStatsTypes;
 import com.royware.corona.dashboard.enums.data.MovingAverageSizes;
-import com.royware.corona.dashboard.enums.regions.RegionsData;
 import com.royware.corona.dashboard.enums.regions.RegionsInDashboard;
 import com.royware.corona.dashboard.interfaces.dashboard.DashboardChartService;
 import com.royware.corona.dashboard.interfaces.dashboard.DashboardConfigService;
@@ -20,7 +19,6 @@ import com.royware.corona.dashboard.interfaces.data.IExternalDataConnectionServi
 import com.royware.corona.dashboard.interfaces.data.ExternalDataServiceFactory;
 import com.royware.corona.dashboard.interfaces.data.IMultiRegionExternalDataService;
 import com.royware.corona.dashboard.interfaces.data.external.IExternalDataGetterStore;
-import com.royware.corona.dashboard.interfaces.data.external.IRegionDemographicDataGetterFactory;
 import com.royware.corona.dashboard.interfaces.data.external.IRegionDemographicDataGetterStore;
 import com.royware.corona.dashboard.interfaces.model.CanonicalCaseDeathData;
 import com.royware.corona.dashboard.model.dashboard.DashboardHeader;
@@ -99,8 +97,12 @@ public class DashboardConfigServiceImpl implements DashboardConfigService {
 			//dashboardChartService.makeDashboardRowByUsTotals(regionPopulation, dashStats);
 			log.info("Making all the DASHBOARD STATISTICS FOR REGION - BY U.S. TOTALS");
 			log.debug("Getting U.S. data for populating By U.S. Totals row of dashboard...");
-			List<UnitedStatesData> usaData = RegionsData.USA
-				.getCoronaVirusDataFromExternalSource(getExternalDataServiceFromFactory(RegionsData.USA.name()));
+			
+			List<UnitedStatesData> usaData = externalDataGetterStore.getDataFor(RegionsInDashboard.USA, dataService);
+
+//			List<UnitedStatesData> usaData = RegionsData.USA
+//				.getCoronaVirusDataFromExternalSource(getExternalDataServiceFromFactory(RegionsData.USA.name()));
+			
 			dashStats = dashStatsStore.produceDashboardStatsForType(DashStatsTypes.DASHSTATS_BY_US_TOTALS, dashStats, usaData, null, regionPopulation);
 		}
 		

--- a/src/main/java/com/royware/corona/dashboard/services/dashboard/DashboardConfigServiceImpl.java
+++ b/src/main/java/com/royware/corona/dashboard/services/dashboard/DashboardConfigServiceImpl.java
@@ -12,28 +12,28 @@ import org.springframework.ui.ModelMap;
 import com.royware.corona.dashboard.enums.dashstats.DashStatsTypes;
 import com.royware.corona.dashboard.enums.data.MovingAverageSizes;
 import com.royware.corona.dashboard.enums.regions.RegionsInDashboard;
-import com.royware.corona.dashboard.interfaces.dashboard.DashboardChartService;
-import com.royware.corona.dashboard.interfaces.dashboard.DashboardConfigService;
+import com.royware.corona.dashboard.interfaces.dashboard.IDashboardChartService;
+import com.royware.corona.dashboard.interfaces.dashboard.IDashboardConfigService;
 import com.royware.corona.dashboard.interfaces.dashboard.IDashStatsStore;
 import com.royware.corona.dashboard.interfaces.data.IExternalDataConnectionService;
-import com.royware.corona.dashboard.interfaces.data.ExternalDataServiceFactory;
+import com.royware.corona.dashboard.interfaces.data.IExternalDataServiceFactory;
 import com.royware.corona.dashboard.interfaces.data.IMultiRegionExternalDataService;
 import com.royware.corona.dashboard.interfaces.data.external.IExternalDataGetterStore;
 import com.royware.corona.dashboard.interfaces.data.external.IRegionDemographicDataGetterStore;
-import com.royware.corona.dashboard.interfaces.model.CanonicalCaseDeathData;
+import com.royware.corona.dashboard.interfaces.model.ICanonicalCaseDeathData;
 import com.royware.corona.dashboard.model.dashboard.DashboardHeader;
 import com.royware.corona.dashboard.model.dashboard.DashboardMeta;
 import com.royware.corona.dashboard.model.dashboard.DashboardStatistics;
 import com.royware.corona.dashboard.model.data.us.UnitedStatesData;
 
 @Component
-public class DashboardConfigServiceImpl implements DashboardConfigService {
+public class DashboardConfigServiceImpl implements IDashboardConfigService {
 	@Autowired private IDashStatsStore dashStatsStore;
-	@Autowired private ExternalDataServiceFactory dataFactory;
+	@Autowired private IExternalDataServiceFactory dataFactory;
 	@Autowired private DashboardMeta dashMeta;
 	@Autowired private DashboardHeader dashHeader;
 	@Autowired private DashboardStatistics dashStats;
-	@Autowired private DashboardChartService dashboardChartService;
+	@Autowired private IDashboardChartService dashboardChartService;
 	@Autowired private IMultiRegionExternalDataService dashboardMultiRegionService;
 	@Autowired private IRegionDemographicDataGetterStore regionDemoDataStore;
 	@Autowired private IExternalDataGetterStore externalDataGetterStore;
@@ -42,7 +42,7 @@ public class DashboardConfigServiceImpl implements DashboardConfigService {
 	
 	@Override
 	public boolean populateDashboardModelMap(String rawRegionString, ModelMap map) {
-		List<? extends CanonicalCaseDeathData> dataList = new ArrayList<>();
+		List<? extends ICanonicalCaseDeathData> dataList = new ArrayList<>();
 		String fullRegionString;
 		int regionPopulation;
 		boolean isMultiRegion = rawRegionString.length() > 3 ? rawRegionString.substring(0,5).equalsIgnoreCase("MULTI") : false;

--- a/src/main/java/com/royware/corona/dashboard/services/dashstats/factory/DashStatsStore.java
+++ b/src/main/java/com/royware/corona/dashboard/services/dashstats/factory/DashStatsStore.java
@@ -9,7 +9,7 @@ import org.springframework.stereotype.Component;
 import com.royware.corona.dashboard.enums.dashstats.DashStatsTypes;
 import com.royware.corona.dashboard.interfaces.dashboard.IDashStatsFactory;
 import com.royware.corona.dashboard.interfaces.dashboard.IDashStatsStore;
-import com.royware.corona.dashboard.interfaces.model.CanonicalCaseDeathData;
+import com.royware.corona.dashboard.interfaces.model.ICanonicalCaseDeathData;
 import com.royware.corona.dashboard.model.dashboard.DashboardStatistics;
 
 @Component
@@ -18,7 +18,7 @@ public class DashStatsStore implements IDashStatsStore {
 	private IDashStatsFactory dashStatsFactory;
 	
 	@Override
-	public <T extends CanonicalCaseDeathData, C extends List<M>, M extends Map<Object, Object>> DashboardStatistics
+	public <T extends ICanonicalCaseDeathData, C extends List<M>, M extends Map<Object, Object>> DashboardStatistics
 		produceDashboardStatsForType(
 			DashStatsTypes statsType,
 			DashboardStatistics dashStats,

--- a/src/main/java/com/royware/corona/dashboard/services/dashstats/makers/DashStatsByUSTotalsMaker.java
+++ b/src/main/java/com/royware/corona/dashboard/services/dashstats/makers/DashStatsByUSTotalsMaker.java
@@ -6,7 +6,7 @@ import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.royware.corona.dashboard.enums.regions.RegionsData;
+import com.royware.corona.dashboard.enums.regions.RegionsInDashboard;
 import com.royware.corona.dashboard.interfaces.dashboard.IDashStatsMaker;
 import com.royware.corona.dashboard.interfaces.model.CanonicalCaseDeathData;
 import com.royware.corona.dashboard.model.dashboard.DashboardStatistics;
@@ -33,7 +33,7 @@ public class DashStatsByUSTotalsMaker implements IDashStatsMaker {
 		log.debug("Making proportionOfRegionDeathsToUsCases");
 		dashStats.setProportionOfRegionDeathsToUsDeaths(dashStats.getDeathsTotal() * 100.0 / totalUSDeaths);
 		log.debug("Making proportionOfRegionPopToUsPop");
-		dashStats.setProportionOfRegionPopToUsPop(regionPop * 100.0 / RegionsData.USA.getRegionData().getPopulation());
+		dashStats.setProportionOfRegionPopToUsPop(regionPop * 100.0 / RegionsInDashboard.USA.getPopulation());
 		int totalUSVacc = dataList.get(dataList.size() - 1).getTotalVaccCompleted();
 		log.debug("Making totalUSVacc");
 		dashStats.setTotalUsVacc(totalUSVacc);
@@ -42,5 +42,4 @@ public class DashStatsByUSTotalsMaker implements IDashStatsMaker {
 		
 		return dashStats;
 	}
-
 }

--- a/src/main/java/com/royware/corona/dashboard/services/dashstats/makers/DashStatsByUSTotalsMaker.java
+++ b/src/main/java/com/royware/corona/dashboard/services/dashstats/makers/DashStatsByUSTotalsMaker.java
@@ -8,14 +8,14 @@ import org.slf4j.LoggerFactory;
 
 import com.royware.corona.dashboard.enums.regions.RegionsInDashboard;
 import com.royware.corona.dashboard.interfaces.dashboard.IDashStatsMaker;
-import com.royware.corona.dashboard.interfaces.model.CanonicalCaseDeathData;
+import com.royware.corona.dashboard.interfaces.model.ICanonicalCaseDeathData;
 import com.royware.corona.dashboard.model.dashboard.DashboardStatistics;
 
 public class DashStatsByUSTotalsMaker implements IDashStatsMaker {
 	private static final Logger log = LoggerFactory.getLogger(DashStatsByUSTotalsMaker.class);
 	
 	@Override
-	public <T extends CanonicalCaseDeathData, C extends List<M>, M extends Map<Object, Object>> DashboardStatistics makeStats(
+	public <T extends ICanonicalCaseDeathData, C extends List<M>, M extends Map<Object, Object>> DashboardStatistics makeStats(
 			DashboardStatistics dashStats, List<T> dataList, List<C> chartData, int regionPop) {
 		
 		if(dashStats == null) {

--- a/src/main/java/com/royware/corona/dashboard/services/dashstats/makers/DashStatsForRegionCasesMaker.java
+++ b/src/main/java/com/royware/corona/dashboard/services/dashstats/makers/DashStatsForRegionCasesMaker.java
@@ -4,13 +4,13 @@ import java.util.List;
 import java.util.Map;
 
 import com.royware.corona.dashboard.interfaces.dashboard.IDashStatsMaker;
-import com.royware.corona.dashboard.interfaces.model.CanonicalCaseDeathData;
+import com.royware.corona.dashboard.interfaces.model.ICanonicalCaseDeathData;
 import com.royware.corona.dashboard.model.dashboard.DashboardStatistics;
 
 public class DashStatsForRegionCasesMaker implements IDashStatsMaker {
 
 	@Override
-	public <T extends CanonicalCaseDeathData, C extends List<M>, M extends Map<Object, Object>> DashboardStatistics makeStats(
+	public <T extends ICanonicalCaseDeathData, C extends List<M>, M extends Map<Object, Object>> DashboardStatistics makeStats(
 			DashboardStatistics dashStats, List<T> dataList, List<C> chartData, int regionPop) {
 		
 		if(dashStats == null) {

--- a/src/main/java/com/royware/corona/dashboard/services/dashstats/makers/DashStatsForRegionCasesMovingSumMaker.java
+++ b/src/main/java/com/royware/corona/dashboard/services/dashstats/makers/DashStatsForRegionCasesMovingSumMaker.java
@@ -4,13 +4,13 @@ import java.util.List;
 import java.util.Map;
 
 import com.royware.corona.dashboard.interfaces.dashboard.IDashStatsMaker;
-import com.royware.corona.dashboard.interfaces.model.CanonicalCaseDeathData;
+import com.royware.corona.dashboard.interfaces.model.ICanonicalCaseDeathData;
 import com.royware.corona.dashboard.model.dashboard.DashboardStatistics;
 
 public class DashStatsForRegionCasesMovingSumMaker implements IDashStatsMaker {
 
 	@Override
-	public <T extends CanonicalCaseDeathData, C extends List<M>, M extends Map<Object, Object>> DashboardStatistics makeStats(
+	public <T extends ICanonicalCaseDeathData, C extends List<M>, M extends Map<Object, Object>> DashboardStatistics makeStats(
 			DashboardStatistics dashStats, List<T> dataList, List<C> chartData, int regionPop) {
 		
 		if(dashStats == null) {

--- a/src/main/java/com/royware/corona/dashboard/services/dashstats/makers/DashStatsForRegionDeathsMaker.java
+++ b/src/main/java/com/royware/corona/dashboard/services/dashstats/makers/DashStatsForRegionDeathsMaker.java
@@ -4,13 +4,13 @@ import java.util.List;
 import java.util.Map;
 
 import com.royware.corona.dashboard.interfaces.dashboard.IDashStatsMaker;
-import com.royware.corona.dashboard.interfaces.model.CanonicalCaseDeathData;
+import com.royware.corona.dashboard.interfaces.model.ICanonicalCaseDeathData;
 import com.royware.corona.dashboard.model.dashboard.DashboardStatistics;
 
 public class DashStatsForRegionDeathsMaker implements IDashStatsMaker {
 
 	@Override
-	public <T extends CanonicalCaseDeathData, C extends List<M>, M extends Map<Object, Object>> DashboardStatistics makeStats(
+	public <T extends ICanonicalCaseDeathData, C extends List<M>, M extends Map<Object, Object>> DashboardStatistics makeStats(
 			DashboardStatistics dashStats, List<T> dataList, List<C> chartData, int regionPop) {
 		
 		if(dashStats == null) {

--- a/src/main/java/com/royware/corona/dashboard/services/dashstats/makers/DashStatsForRegionDeathsMovingSumMaker.java
+++ b/src/main/java/com/royware/corona/dashboard/services/dashstats/makers/DashStatsForRegionDeathsMovingSumMaker.java
@@ -5,7 +5,7 @@ import java.util.Map;
 
 import com.royware.corona.dashboard.enums.data.MovingAverageSizes;
 import com.royware.corona.dashboard.interfaces.dashboard.IDashStatsMaker;
-import com.royware.corona.dashboard.interfaces.model.CanonicalCaseDeathData;
+import com.royware.corona.dashboard.interfaces.model.ICanonicalCaseDeathData;
 import com.royware.corona.dashboard.model.dashboard.DashboardStatistics;
 import com.royware.corona.dashboard.services.chart.config.makers.ChartConfigMakerUtilities;
 
@@ -13,7 +13,7 @@ public class DashStatsForRegionDeathsMovingSumMaker implements IDashStatsMaker {
 
 	@SuppressWarnings("unchecked")
 	@Override
-	public <T extends CanonicalCaseDeathData, C extends List<M>, M extends Map<Object, Object>> DashboardStatistics makeStats(
+	public <T extends ICanonicalCaseDeathData, C extends List<M>, M extends Map<Object, Object>> DashboardStatistics makeStats(
 			DashboardStatistics dashStats, List<T> dataList, List<C> chartData, int regionPop) {
 		
 		if(dashStats == null) {

--- a/src/main/java/com/royware/corona/dashboard/services/dashstats/makers/DashStatsForRegionVaccMaker.java
+++ b/src/main/java/com/royware/corona/dashboard/services/dashstats/makers/DashStatsForRegionVaccMaker.java
@@ -5,7 +5,7 @@ import java.util.Map;
 
 import com.royware.corona.dashboard.enums.data.MovingAverageSizes;
 import com.royware.corona.dashboard.interfaces.dashboard.IDashStatsMaker;
-import com.royware.corona.dashboard.interfaces.model.CanonicalCaseDeathData;
+import com.royware.corona.dashboard.interfaces.model.ICanonicalCaseDeathData;
 import com.royware.corona.dashboard.model.dashboard.DashboardStatistics;
 import com.royware.corona.dashboard.services.chart.config.makers.ChartConfigMakerUtilities;
 
@@ -13,7 +13,7 @@ public class DashStatsForRegionVaccMaker implements IDashStatsMaker {
 
 	@SuppressWarnings("unchecked")
 	@Override
-	public <T extends CanonicalCaseDeathData, C extends List<M>, M extends Map<Object, Object>> DashboardStatistics makeStats(
+	public <T extends ICanonicalCaseDeathData, C extends List<M>, M extends Map<Object, Object>> DashboardStatistics makeStats(
 			DashboardStatistics dashStats, List<T> dataList, List<C> chartData, int regionPop) {
 		
 		if(dashStats == null) {

--- a/src/main/java/com/royware/corona/dashboard/services/dashstats/makers/DashStatsForUSRegionsByTestingMaker.java
+++ b/src/main/java/com/royware/corona/dashboard/services/dashstats/makers/DashStatsForUSRegionsByTestingMaker.java
@@ -9,7 +9,7 @@ import org.slf4j.LoggerFactory;
 import com.royware.corona.dashboard.enums.data.MovingAverageSizes;
 import com.royware.corona.dashboard.enums.regions.RegionsInDashboard;
 import com.royware.corona.dashboard.interfaces.dashboard.IDashStatsMaker;
-import com.royware.corona.dashboard.interfaces.model.CanonicalCaseDeathData;
+import com.royware.corona.dashboard.interfaces.model.ICanonicalCaseDeathData;
 import com.royware.corona.dashboard.model.dashboard.DashboardStatistics;
 import com.royware.corona.dashboard.services.chart.config.makers.ChartConfigMakerUtilities;
 
@@ -18,7 +18,7 @@ public class DashStatsForUSRegionsByTestingMaker implements IDashStatsMaker {
 	
 	@SuppressWarnings("unchecked")
 	@Override
-	public <T extends CanonicalCaseDeathData, C extends List<M>, M extends Map<Object, Object>> DashboardStatistics makeStats(
+	public <T extends ICanonicalCaseDeathData, C extends List<M>, M extends Map<Object, Object>> DashboardStatistics makeStats(
 			DashboardStatistics dashStats, List<T> dataList, List<C> chartData, int regionPop) {
 		
 		if(dashStats == null) {

--- a/src/main/java/com/royware/corona/dashboard/services/dashstats/makers/DashStatsForUSRegionsByTestingMaker.java
+++ b/src/main/java/com/royware/corona/dashboard/services/dashstats/makers/DashStatsForUSRegionsByTestingMaker.java
@@ -7,7 +7,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.royware.corona.dashboard.enums.data.MovingAverageSizes;
-import com.royware.corona.dashboard.enums.regions.RegionsData;
+import com.royware.corona.dashboard.enums.regions.RegionsInDashboard;
 import com.royware.corona.dashboard.interfaces.dashboard.IDashStatsMaker;
 import com.royware.corona.dashboard.interfaces.model.CanonicalCaseDeathData;
 import com.royware.corona.dashboard.model.dashboard.DashboardStatistics;
@@ -26,7 +26,7 @@ public class DashStatsForUSRegionsByTestingMaker implements IDashStatsMaker {
 		}
 		
 		log.debug("Getting the region population from the Regions enum");
-		int usaPop = RegionsData.USA.getRegionData().getPopulation();
+		int usaPop = RegionsInDashboard.USA.getPopulation();
 		log.debug("Making total tests conducted");
 		dashStats.setTotalTestsConducted(dataList.get(dataList.size() - 1).getTotalPositiveCases()
 				+ dataList.get(dataList.size() - 1).getTotalNegativeCases());

--- a/src/main/java/com/royware/corona/dashboard/services/dashstats/makers/DashStatsForUSRegionsProportionsMaker.java
+++ b/src/main/java/com/royware/corona/dashboard/services/dashstats/makers/DashStatsForUSRegionsProportionsMaker.java
@@ -8,14 +8,14 @@ import org.slf4j.LoggerFactory;
 
 import com.royware.corona.dashboard.enums.regions.RegionsInDashboard;
 import com.royware.corona.dashboard.interfaces.dashboard.IDashStatsMaker;
-import com.royware.corona.dashboard.interfaces.model.CanonicalCaseDeathData;
+import com.royware.corona.dashboard.interfaces.model.ICanonicalCaseDeathData;
 import com.royware.corona.dashboard.model.dashboard.DashboardStatistics;
 
 public class DashStatsForUSRegionsProportionsMaker implements IDashStatsMaker {
 	private static final Logger log = LoggerFactory.getLogger(DashStatsForUSRegionsProportionsMaker.class);
 	
 	@Override
-	public <T extends CanonicalCaseDeathData, C extends List<M>, M extends Map<Object, Object>> DashboardStatistics makeStats(
+	public <T extends ICanonicalCaseDeathData, C extends List<M>, M extends Map<Object, Object>> DashboardStatistics makeStats(
 			DashboardStatistics dashStats, List<T> dataList, List<C> chartData, int regionPop) {
 		
 		if(dashStats == null) {

--- a/src/main/java/com/royware/corona/dashboard/services/dashstats/makers/DashStatsForUSRegionsProportionsMaker.java
+++ b/src/main/java/com/royware/corona/dashboard/services/dashstats/makers/DashStatsForUSRegionsProportionsMaker.java
@@ -6,7 +6,7 @@ import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.royware.corona.dashboard.enums.regions.RegionsData;
+import com.royware.corona.dashboard.enums.regions.RegionsInDashboard;
 import com.royware.corona.dashboard.interfaces.dashboard.IDashStatsMaker;
 import com.royware.corona.dashboard.interfaces.model.CanonicalCaseDeathData;
 import com.royware.corona.dashboard.model.dashboard.DashboardStatistics;
@@ -23,7 +23,7 @@ public class DashStatsForUSRegionsProportionsMaker implements IDashStatsMaker {
 		}
 		
 		log.debug("Getting the region population from the Regions enum");
-		int usaPop = RegionsData.USA.getRegionData().getPopulation();
+		int usaPop = RegionsInDashboard.USA.getPopulation();
 		log.debug("Making ProportionOfDeathsFromPositives");
 		dashStats.setProportionOfDeathsFromPositives(dataList.get(dataList.size() - 1).getTotalDeaths()
 				* 100.0 / dataList.get(dataList.size() - 1).getTotalPositiveCases());

--- a/src/main/java/com/royware/corona/dashboard/services/dashstats/makers/DashStatsPerCapitaStatsMaker.java
+++ b/src/main/java/com/royware/corona/dashboard/services/dashstats/makers/DashStatsPerCapitaStatsMaker.java
@@ -5,13 +5,13 @@ import java.util.Map;
 
 import com.royware.corona.dashboard.enums.data.MovingAverageSizes;
 import com.royware.corona.dashboard.interfaces.dashboard.IDashStatsMaker;
-import com.royware.corona.dashboard.interfaces.model.CanonicalCaseDeathData;
+import com.royware.corona.dashboard.interfaces.model.ICanonicalCaseDeathData;
 import com.royware.corona.dashboard.model.dashboard.DashboardStatistics;
 
 public class DashStatsPerCapitaStatsMaker implements IDashStatsMaker {
 	
 	@Override
-	public <T extends CanonicalCaseDeathData, C extends List<M>, M extends Map<Object, Object>> DashboardStatistics makeStats(
+	public <T extends ICanonicalCaseDeathData, C extends List<M>, M extends Map<Object, Object>> DashboardStatistics makeStats(
 			DashboardStatistics dashStats, List<T> dataList, List<C> chartData, int regionPop) {
 		
 		if(dashStats == null) {

--- a/src/main/java/com/royware/corona/dashboard/services/data/cache/CacheActionsUnitedStatesImpl.java
+++ b/src/main/java/com/royware/corona/dashboard/services/data/cache/CacheActionsUnitedStatesImpl.java
@@ -11,7 +11,7 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 import com.royware.corona.dashboard.enums.data.CacheKeys;
-import com.royware.corona.dashboard.interfaces.data.ExternalDataService;
+import com.royware.corona.dashboard.interfaces.data.IExternalDataConnectionService;
 import com.royware.corona.dashboard.interfaces.data.ICacheActions;
 import com.royware.corona.dashboard.interfaces.model.CanonicalCaseDeathData;
 import com.royware.corona.dashboard.model.data.us.UnitedStatesData;
@@ -24,7 +24,7 @@ public class CacheActionsUnitedStatesImpl implements ICacheActions {
 	
 	@Autowired
 	@Qualifier(value = "us")
-	private ExternalDataService usaDataService;
+	private IExternalDataConnectionService usaDataService;
 		
 	@Override
 	@Scheduled(initialDelayString = "${spring.cache.refresh.period.usa}", fixedDelayString = "${spring.cache.refresh.period.usa}")

--- a/src/main/java/com/royware/corona/dashboard/services/data/cache/CacheActionsUnitedStatesImpl.java
+++ b/src/main/java/com/royware/corona/dashboard/services/data/cache/CacheActionsUnitedStatesImpl.java
@@ -13,7 +13,7 @@ import org.springframework.stereotype.Component;
 import com.royware.corona.dashboard.enums.data.CacheKeys;
 import com.royware.corona.dashboard.interfaces.data.IExternalDataConnectionService;
 import com.royware.corona.dashboard.interfaces.data.ICacheActions;
-import com.royware.corona.dashboard.interfaces.model.CanonicalCaseDeathData;
+import com.royware.corona.dashboard.interfaces.model.ICanonicalCaseDeathData;
 import com.royware.corona.dashboard.model.data.us.UnitedStatesData;
 import com.royware.corona.dashboard.services.data.world.ExternalDataServiceWorldImpl;
 
@@ -56,7 +56,7 @@ public class CacheActionsUnitedStatesImpl implements ICacheActions {
 	}	
 
 	@Override
-	public <T extends CanonicalCaseDeathData> void populateCacheFromDataList(String cacheKey, List<T> newCacheData) {
+	public <T extends ICanonicalCaseDeathData> void populateCacheFromDataList(String cacheKey, List<T> newCacheData) {
 		log.debug("In the populateCacheFromExistingData method: " + LocalDateTime.now());
 		putDataIntoCache(cacheKey, newCacheData);
 	}
@@ -72,7 +72,7 @@ public class CacheActionsUnitedStatesImpl implements ICacheActions {
 		return usaDataService.makeDataListFromExternalSource(CACHE_KEY);
 	}
 
-	private <T extends CanonicalCaseDeathData> void putDataIntoCache(String cacheKey, List<T> newCacheData) {
+	private <T extends ICanonicalCaseDeathData> void putDataIntoCache(String cacheKey, List<T> newCacheData) {
 		CacheManagerProvider.getManager().put(cacheKey, newCacheData);
 	}
 }

--- a/src/main/java/com/royware/corona/dashboard/services/data/cache/CacheActionsWorldImpl.java
+++ b/src/main/java/com/royware/corona/dashboard/services/data/cache/CacheActionsWorldImpl.java
@@ -11,8 +11,8 @@ import org.springframework.stereotype.Component;
 
 import com.royware.corona.dashboard.enums.data.CacheKeys;
 import com.royware.corona.dashboard.interfaces.data.ICacheActions;
-import com.royware.corona.dashboard.interfaces.data.WorldDataServiceCaller;
-import com.royware.corona.dashboard.interfaces.model.CanonicalCaseDeathData;
+import com.royware.corona.dashboard.interfaces.data.IWorldDataServiceCaller;
+import com.royware.corona.dashboard.interfaces.model.ICanonicalCaseDeathData;
 import com.royware.corona.dashboard.model.data.world.WorldData;
 import com.royware.corona.dashboard.services.data.world.ExternalDataServiceWorldImpl;
 
@@ -22,7 +22,7 @@ public class CacheActionsWorldImpl implements ICacheActions {
 	private static final String CACHE_KEY = CacheKeys.CACHE_KEY_WORLD.getName();
 	
 	@Autowired
-	private WorldDataServiceCaller worldDataServiceCaller;
+	private IWorldDataServiceCaller worldDataServiceCaller;
 	
 	@Override
 	@Scheduled(initialDelayString = "${spring.cache.refresh.period.world}", fixedDelayString = "${spring.cache.refresh.period.world}")
@@ -55,7 +55,7 @@ public class CacheActionsWorldImpl implements ICacheActions {
 	}	
 
 	@Override
-	public <T extends CanonicalCaseDeathData> void populateCacheFromDataList(String cacheKey, List<T> newCacheData) {
+	public <T extends ICanonicalCaseDeathData> void populateCacheFromDataList(String cacheKey, List<T> newCacheData) {
 		log.debug("In the populateCacheFromExistingData method: " + LocalDateTime.now());
 		CacheManagerProvider.getManager().put(cacheKey, newCacheData);
 	}

--- a/src/main/java/com/royware/corona/dashboard/services/data/common/ExternalDataServiceFactoryImpl.java
+++ b/src/main/java/com/royware/corona/dashboard/services/data/common/ExternalDataServiceFactoryImpl.java
@@ -8,10 +8,10 @@ import org.springframework.stereotype.Service;
 
 import com.royware.corona.dashboard.enums.regions.RegionsInDashboard;
 import com.royware.corona.dashboard.interfaces.data.IExternalDataConnectionService;
-import com.royware.corona.dashboard.interfaces.data.ExternalDataServiceFactory;
+import com.royware.corona.dashboard.interfaces.data.IExternalDataServiceFactory;
 
 @Service
-public class ExternalDataServiceFactoryImpl implements ExternalDataServiceFactory {
+public class ExternalDataServiceFactoryImpl implements IExternalDataServiceFactory {
 	@Autowired
 	@Qualifier(value = "us")
 	private IExternalDataConnectionService usDataService;

--- a/src/main/java/com/royware/corona/dashboard/services/data/common/ExternalDataServiceFactoryImpl.java
+++ b/src/main/java/com/royware/corona/dashboard/services/data/common/ExternalDataServiceFactoryImpl.java
@@ -7,36 +7,36 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 
 import com.royware.corona.dashboard.enums.regions.RegionsData;
-import com.royware.corona.dashboard.interfaces.data.ExternalDataService;
+import com.royware.corona.dashboard.interfaces.data.IExternalDataConnectionService;
 import com.royware.corona.dashboard.interfaces.data.ExternalDataServiceFactory;
 
 @Service
 public class ExternalDataServiceFactoryImpl implements ExternalDataServiceFactory {
 	@Autowired
 	@Qualifier(value = "us")
-	private ExternalDataService usDataService;
+	private IExternalDataConnectionService usDataService;
 	
 	@Autowired
 	@Qualifier(value = "singleState")
-	private ExternalDataService singleStateDataService;
+	private IExternalDataConnectionService singleStateDataService;
 	
 	@Autowired
 	@Qualifier(value = "multiState")
-	private ExternalDataService multiStateDataService;
+	private IExternalDataConnectionService multiStateDataService;
 	
 	@Autowired
 	@Qualifier(value = "usExcludingState")
-	private ExternalDataService usExcludingStateDataService;
+	private IExternalDataConnectionService usExcludingStateDataService;
 	
 	@Autowired
 	@Qualifier(value = "singleCountry")
-	private ExternalDataService singleCountryDataService;
+	private IExternalDataConnectionService singleCountryDataService;
 	
 	private static final Logger log = LoggerFactory.getLogger(ExternalDataServiceFactoryImpl.class);
 	
 	@Override
-	public ExternalDataService getExternalDataService(String regionOfService) {
-		ExternalDataService dataService;
+	public IExternalDataConnectionService getExternalDataService(String regionOfService) {
+		IExternalDataConnectionService dataService;
 		
 		log.debug("getExternalDataService trying to make dataService for " + regionOfService);
 		if(regionOfService.equalsIgnoreCase(RegionsData.USA.name())) {

--- a/src/main/java/com/royware/corona/dashboard/services/data/common/ExternalDataServiceFactoryImpl.java
+++ b/src/main/java/com/royware/corona/dashboard/services/data/common/ExternalDataServiceFactoryImpl.java
@@ -6,7 +6,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 
-import com.royware.corona.dashboard.enums.regions.RegionsData;
+import com.royware.corona.dashboard.enums.regions.RegionsInDashboard;
 import com.royware.corona.dashboard.interfaces.data.IExternalDataConnectionService;
 import com.royware.corona.dashboard.interfaces.data.ExternalDataServiceFactory;
 
@@ -39,10 +39,10 @@ public class ExternalDataServiceFactoryImpl implements ExternalDataServiceFactor
 		IExternalDataConnectionService dataService;
 		
 		log.debug("getExternalDataService trying to make dataService for " + regionOfService);
-		if(regionOfService.equalsIgnoreCase(RegionsData.USA.name())) {
-			log.debug("Making dataService for " + RegionsData.USA.name());
+		if(regionOfService.equalsIgnoreCase(RegionsInDashboard.USA.name())) {
+			log.debug("Making dataService for " + RegionsInDashboard.USA.name());
 			dataService = usDataService;
-		} else if(regionOfService.equalsIgnoreCase(RegionsData.USA_NO_NY.name())) {
+		} else if(regionOfService.equalsIgnoreCase(RegionsInDashboard.USA_NO_NY.name())) {
 			dataService = usExcludingStateDataService;
 		} else if(regionOfService.length() == 2) {
 			dataService = singleStateDataService;
@@ -57,5 +57,4 @@ public class ExternalDataServiceFactoryImpl implements ExternalDataServiceFactor
 		
 		return dataService;
 	}
-
 }

--- a/src/main/java/com/royware/corona/dashboard/services/data/external/factory/ExternalDataGetterFactory.java
+++ b/src/main/java/com/royware/corona/dashboard/services/data/external/factory/ExternalDataGetterFactory.java
@@ -1,0 +1,22 @@
+package com.royware.corona.dashboard.services.data.external.factory;
+
+import org.springframework.stereotype.Component;
+
+import com.royware.corona.dashboard.enums.regions.RegionsInDashboard;
+import com.royware.corona.dashboard.services.data.external.getters.USADataGetter;
+import com.royware.corona.dashboard.services.data.external.getters.USAStateOrWorldCountryDataGetter;
+import com.royware.corona.dashboard.services.data.external.getters.USAWithoutNYDataGetter;
+import com.royware.corona.dashboard.interfaces.data.external.IExternalDataGetter;
+import com.royware.corona.dashboard.interfaces.data.external.IExternalDataGetterFactory;
+
+@Component
+public class ExternalDataGetterFactory implements IExternalDataGetterFactory {		
+	@Override
+	public IExternalDataGetter create(RegionsInDashboard region) {		
+		switch(region) {
+			case USA: return new USADataGetter();
+			case USA_NO_NY: return new USAWithoutNYDataGetter();
+			default: return new USAStateOrWorldCountryDataGetter();
+		}		
+	}
+}

--- a/src/main/java/com/royware/corona/dashboard/services/data/external/factory/ExternalDataGetterStore.java
+++ b/src/main/java/com/royware/corona/dashboard/services/data/external/factory/ExternalDataGetterStore.java
@@ -9,14 +9,14 @@ import com.royware.corona.dashboard.enums.regions.RegionsInDashboard;
 import com.royware.corona.dashboard.interfaces.data.IExternalDataConnectionService;
 import com.royware.corona.dashboard.interfaces.data.external.IExternalDataGetterFactory;
 import com.royware.corona.dashboard.interfaces.data.external.IExternalDataGetterStore;
-import com.royware.corona.dashboard.interfaces.model.CanonicalCaseDeathData;
+import com.royware.corona.dashboard.interfaces.model.ICanonicalCaseDeathData;
 
 @Component
 public class ExternalDataGetterStore implements IExternalDataGetterStore {
 	@Autowired private IExternalDataGetterFactory dataGetterFactory;
 	
 	@Override
-	public <T extends CanonicalCaseDeathData> List<T> getDataFor(
+	public <T extends ICanonicalCaseDeathData> List<T> getDataFor(
 			RegionsInDashboard region,
 			IExternalDataConnectionService externalDataService) {
 		

--- a/src/main/java/com/royware/corona/dashboard/services/data/external/factory/ExternalDataGetterStore.java
+++ b/src/main/java/com/royware/corona/dashboard/services/data/external/factory/ExternalDataGetterStore.java
@@ -1,0 +1,25 @@
+package com.royware.corona.dashboard.services.data.external.factory;
+
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import com.royware.corona.dashboard.enums.regions.RegionsInDashboard;
+import com.royware.corona.dashboard.interfaces.data.IExternalDataConnectionService;
+import com.royware.corona.dashboard.interfaces.data.external.IExternalDataGetterFactory;
+import com.royware.corona.dashboard.interfaces.data.external.IExternalDataGetterStore;
+import com.royware.corona.dashboard.interfaces.model.CanonicalCaseDeathData;
+
+@Component
+public class ExternalDataGetterStore implements IExternalDataGetterStore {
+	@Autowired private IExternalDataGetterFactory dataGetterFactory;
+	
+	@Override
+	public <T extends CanonicalCaseDeathData> List<T> getDataFor(
+			RegionsInDashboard region,
+			IExternalDataConnectionService externalDataService) {
+		
+		return dataGetterFactory.create(region).getDataUsing(externalDataService, region);
+	}	
+}

--- a/src/main/java/com/royware/corona/dashboard/services/data/external/factory/RegionDemographicDataGetterFactory.java
+++ b/src/main/java/com/royware/corona/dashboard/services/data/external/factory/RegionDemographicDataGetterFactory.java
@@ -1,0 +1,15 @@
+package com.royware.corona.dashboard.services.data.external.factory;
+
+import org.springframework.stereotype.Component;
+
+import com.royware.corona.dashboard.enums.regions.RegionsInDashboard;
+import com.royware.corona.dashboard.interfaces.data.external.IRegionDemographicDataGetterFactory;
+import com.royware.corona.dashboard.model.data.common.RegionData;
+
+@Component
+public class RegionDemographicDataGetterFactory implements IRegionDemographicDataGetterFactory {			
+	@Override
+	public RegionData getRegionDataFor(RegionsInDashboard region) {
+		return new RegionData(region.getPopulation(), region.getRegionType(), region.getLabel());
+	}
+}

--- a/src/main/java/com/royware/corona/dashboard/services/data/external/factory/RegionDemographicDataGetterStore.java
+++ b/src/main/java/com/royware/corona/dashboard/services/data/external/factory/RegionDemographicDataGetterStore.java
@@ -1,0 +1,22 @@
+package com.royware.corona.dashboard.services.data.external.factory;
+
+import org.springframework.beans.factory.annotation.Autowired;
+
+import com.royware.corona.dashboard.enums.regions.RegionsInDashboard;
+import com.royware.corona.dashboard.interfaces.data.external.IRegionDemographicDataGetterFactory;
+import com.royware.corona.dashboard.interfaces.data.external.IRegionDemographicDataGetterStore;
+
+public class RegionDemographicDataGetterStore implements IRegionDemographicDataGetterStore {
+
+	@Autowired private IRegionDemographicDataGetterFactory regionDemographicsFactory;
+	
+	@Override
+	public String getRegionFullNameFor(RegionsInDashboard region) {
+		return regionDemographicsFactory.getRegionDataFor(region).getFullName();
+	}
+
+	@Override
+	public int getRegionPopulationFor(RegionsInDashboard region) {
+		return regionDemographicsFactory.getRegionDataFor(region).getPopulation();
+	}
+}

--- a/src/main/java/com/royware/corona/dashboard/services/data/external/factory/RegionDemographicDataGetterStore.java
+++ b/src/main/java/com/royware/corona/dashboard/services/data/external/factory/RegionDemographicDataGetterStore.java
@@ -1,11 +1,13 @@
 package com.royware.corona.dashboard.services.data.external.factory;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
 
 import com.royware.corona.dashboard.enums.regions.RegionsInDashboard;
 import com.royware.corona.dashboard.interfaces.data.external.IRegionDemographicDataGetterFactory;
 import com.royware.corona.dashboard.interfaces.data.external.IRegionDemographicDataGetterStore;
 
+@Component
 public class RegionDemographicDataGetterStore implements IRegionDemographicDataGetterStore {
 
 	@Autowired private IRegionDemographicDataGetterFactory regionDemographicsFactory;

--- a/src/main/java/com/royware/corona/dashboard/services/data/external/getters/USADataGetter.java
+++ b/src/main/java/com/royware/corona/dashboard/services/data/external/getters/USADataGetter.java
@@ -1,0 +1,22 @@
+package com.royware.corona.dashboard.services.data.external.getters;
+
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.royware.corona.dashboard.enums.data.CacheKeys;
+import com.royware.corona.dashboard.enums.regions.RegionsInDashboard;
+import com.royware.corona.dashboard.interfaces.data.IExternalDataConnectionService;
+import com.royware.corona.dashboard.interfaces.data.external.IExternalDataGetter;
+import com.royware.corona.dashboard.interfaces.model.CanonicalCaseDeathData;
+
+public class USADataGetter implements IExternalDataGetter {
+
+	@Override
+	public <T extends CanonicalCaseDeathData> List<T> getDataUsing(IExternalDataConnectionService eds, RegionsInDashboard region) {
+		Logger log = LoggerFactory.getLogger(this.getClass().getSimpleName());
+		log.info(this.getClass().getSimpleName() + " is about to call makeDataListFromExternalSource with " + eds.toString());
+		return eds.makeDataListFromExternalSource(CacheKeys.CACHE_KEY_US.getName());
+	}
+}

--- a/src/main/java/com/royware/corona/dashboard/services/data/external/getters/USADataGetter.java
+++ b/src/main/java/com/royware/corona/dashboard/services/data/external/getters/USADataGetter.java
@@ -9,12 +9,12 @@ import com.royware.corona.dashboard.enums.data.CacheKeys;
 import com.royware.corona.dashboard.enums.regions.RegionsInDashboard;
 import com.royware.corona.dashboard.interfaces.data.IExternalDataConnectionService;
 import com.royware.corona.dashboard.interfaces.data.external.IExternalDataGetter;
-import com.royware.corona.dashboard.interfaces.model.CanonicalCaseDeathData;
+import com.royware.corona.dashboard.interfaces.model.ICanonicalCaseDeathData;
 
 public class USADataGetter implements IExternalDataGetter {
 
 	@Override
-	public <T extends CanonicalCaseDeathData> List<T> getDataUsing(IExternalDataConnectionService eds, RegionsInDashboard region) {
+	public <T extends ICanonicalCaseDeathData> List<T> getDataUsing(IExternalDataConnectionService eds, RegionsInDashboard region) {
 		Logger log = LoggerFactory.getLogger(this.getClass().getSimpleName());
 		log.info(this.getClass().getSimpleName() + " is about to call makeDataListFromExternalSource with " + eds.toString());
 		return eds.makeDataListFromExternalSource(CacheKeys.CACHE_KEY_US.getName());

--- a/src/main/java/com/royware/corona/dashboard/services/data/external/getters/USAStateDataGetter.java
+++ b/src/main/java/com/royware/corona/dashboard/services/data/external/getters/USAStateDataGetter.java
@@ -8,12 +8,12 @@ import org.slf4j.LoggerFactory;
 import com.royware.corona.dashboard.enums.regions.RegionsInDashboard;
 import com.royware.corona.dashboard.interfaces.data.IExternalDataConnectionService;
 import com.royware.corona.dashboard.interfaces.data.external.IExternalDataGetter;
-import com.royware.corona.dashboard.interfaces.model.CanonicalCaseDeathData;
+import com.royware.corona.dashboard.interfaces.model.ICanonicalCaseDeathData;
 
 public class USAStateDataGetter implements IExternalDataGetter {
 
 	@Override
-	public <T extends CanonicalCaseDeathData> List<T> getDataUsing(IExternalDataConnectionService eds, RegionsInDashboard region) {
+	public <T extends ICanonicalCaseDeathData> List<T> getDataUsing(IExternalDataConnectionService eds, RegionsInDashboard region) {
 		Logger log = LoggerFactory.getLogger(this.getClass().getSimpleName());
 		log.info(this.getClass().getSimpleName() + " is about to call makeDataListFromExternalSource with " + eds.toString());
 		return eds.makeDataListFromExternalSource(region.name());

--- a/src/main/java/com/royware/corona/dashboard/services/data/external/getters/USAStateDataGetter.java
+++ b/src/main/java/com/royware/corona/dashboard/services/data/external/getters/USAStateDataGetter.java
@@ -1,0 +1,21 @@
+package com.royware.corona.dashboard.services.data.external.getters;
+
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.royware.corona.dashboard.enums.regions.RegionsInDashboard;
+import com.royware.corona.dashboard.interfaces.data.IExternalDataConnectionService;
+import com.royware.corona.dashboard.interfaces.data.external.IExternalDataGetter;
+import com.royware.corona.dashboard.interfaces.model.CanonicalCaseDeathData;
+
+public class USAStateDataGetter implements IExternalDataGetter {
+
+	@Override
+	public <T extends CanonicalCaseDeathData> List<T> getDataUsing(IExternalDataConnectionService eds, RegionsInDashboard region) {
+		Logger log = LoggerFactory.getLogger(this.getClass().getSimpleName());
+		log.info(this.getClass().getSimpleName() + " is about to call makeDataListFromExternalSource with " + eds.toString());
+		return eds.makeDataListFromExternalSource(region.name());
+	}
+}

--- a/src/main/java/com/royware/corona/dashboard/services/data/external/getters/USAStateOrWorldCountryDataGetter.java
+++ b/src/main/java/com/royware/corona/dashboard/services/data/external/getters/USAStateOrWorldCountryDataGetter.java
@@ -8,12 +8,12 @@ import org.slf4j.LoggerFactory;
 import com.royware.corona.dashboard.enums.regions.RegionsInDashboard;
 import com.royware.corona.dashboard.interfaces.data.IExternalDataConnectionService;
 import com.royware.corona.dashboard.interfaces.data.external.IExternalDataGetter;
-import com.royware.corona.dashboard.interfaces.model.CanonicalCaseDeathData;
+import com.royware.corona.dashboard.interfaces.model.ICanonicalCaseDeathData;
 
 public class USAStateOrWorldCountryDataGetter implements IExternalDataGetter {
 
 	@Override
-	public <T extends CanonicalCaseDeathData> List<T> getDataUsing(IExternalDataConnectionService eds, RegionsInDashboard region) {
+	public <T extends ICanonicalCaseDeathData> List<T> getDataUsing(IExternalDataConnectionService eds, RegionsInDashboard region) {
 		Logger log = LoggerFactory.getLogger(this.getClass().getSimpleName());
 		log.info(this.getClass().getSimpleName() + " is about to call makeDataListFromExternalSource with " + eds.toString());
 		return eds.makeDataListFromExternalSource(region.name());

--- a/src/main/java/com/royware/corona/dashboard/services/data/external/getters/USAStateOrWorldCountryDataGetter.java
+++ b/src/main/java/com/royware/corona/dashboard/services/data/external/getters/USAStateOrWorldCountryDataGetter.java
@@ -1,0 +1,21 @@
+package com.royware.corona.dashboard.services.data.external.getters;
+
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.royware.corona.dashboard.enums.regions.RegionsInDashboard;
+import com.royware.corona.dashboard.interfaces.data.IExternalDataConnectionService;
+import com.royware.corona.dashboard.interfaces.data.external.IExternalDataGetter;
+import com.royware.corona.dashboard.interfaces.model.CanonicalCaseDeathData;
+
+public class USAStateOrWorldCountryDataGetter implements IExternalDataGetter {
+
+	@Override
+	public <T extends CanonicalCaseDeathData> List<T> getDataUsing(IExternalDataConnectionService eds, RegionsInDashboard region) {
+		Logger log = LoggerFactory.getLogger(this.getClass().getSimpleName());
+		log.info(this.getClass().getSimpleName() + " is about to call makeDataListFromExternalSource with " + eds.toString());
+		return eds.makeDataListFromExternalSource(region.name());
+	}
+}

--- a/src/main/java/com/royware/corona/dashboard/services/data/external/getters/USAWithoutNYDataGetter.java
+++ b/src/main/java/com/royware/corona/dashboard/services/data/external/getters/USAWithoutNYDataGetter.java
@@ -1,0 +1,21 @@
+package com.royware.corona.dashboard.services.data.external.getters;
+
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.royware.corona.dashboard.enums.regions.RegionsInDashboard;
+import com.royware.corona.dashboard.interfaces.data.IExternalDataConnectionService;
+import com.royware.corona.dashboard.interfaces.data.external.IExternalDataGetter;
+import com.royware.corona.dashboard.interfaces.model.CanonicalCaseDeathData;
+
+public class USAWithoutNYDataGetter implements IExternalDataGetter {
+
+	@Override
+	public <T extends CanonicalCaseDeathData> List<T> getDataUsing(IExternalDataConnectionService eds, RegionsInDashboard region) {
+		Logger log = LoggerFactory.getLogger(this.getClass().getSimpleName());
+		log.info(this.getClass().getSimpleName() + " is about to call makeDataListFromExternalSource with " + eds.toString());
+		return eds.makeDataListFromExternalSource("NY");
+	}
+}

--- a/src/main/java/com/royware/corona/dashboard/services/data/external/getters/USAWithoutNYDataGetter.java
+++ b/src/main/java/com/royware/corona/dashboard/services/data/external/getters/USAWithoutNYDataGetter.java
@@ -8,12 +8,12 @@ import org.slf4j.LoggerFactory;
 import com.royware.corona.dashboard.enums.regions.RegionsInDashboard;
 import com.royware.corona.dashboard.interfaces.data.IExternalDataConnectionService;
 import com.royware.corona.dashboard.interfaces.data.external.IExternalDataGetter;
-import com.royware.corona.dashboard.interfaces.model.CanonicalCaseDeathData;
+import com.royware.corona.dashboard.interfaces.model.ICanonicalCaseDeathData;
 
 public class USAWithoutNYDataGetter implements IExternalDataGetter {
 
 	@Override
-	public <T extends CanonicalCaseDeathData> List<T> getDataUsing(IExternalDataConnectionService eds, RegionsInDashboard region) {
+	public <T extends ICanonicalCaseDeathData> List<T> getDataUsing(IExternalDataConnectionService eds, RegionsInDashboard region) {
 		Logger log = LoggerFactory.getLogger(this.getClass().getSimpleName());
 		log.info(this.getClass().getSimpleName() + " is about to call makeDataListFromExternalSource with " + eds.toString());
 		return eds.makeDataListFromExternalSource("NY");

--- a/src/main/java/com/royware/corona/dashboard/services/data/external/getters/WorldCountryDataGetter.java
+++ b/src/main/java/com/royware/corona/dashboard/services/data/external/getters/WorldCountryDataGetter.java
@@ -8,12 +8,12 @@ import org.slf4j.LoggerFactory;
 import com.royware.corona.dashboard.enums.regions.RegionsInDashboard;
 import com.royware.corona.dashboard.interfaces.data.IExternalDataConnectionService;
 import com.royware.corona.dashboard.interfaces.data.external.IExternalDataGetter;
-import com.royware.corona.dashboard.interfaces.model.CanonicalCaseDeathData;
+import com.royware.corona.dashboard.interfaces.model.ICanonicalCaseDeathData;
 
 public class WorldCountryDataGetter implements IExternalDataGetter {
 
 	@Override
-	public <T extends CanonicalCaseDeathData> List<T> getDataUsing(IExternalDataConnectionService eds, RegionsInDashboard region) {
+	public <T extends ICanonicalCaseDeathData> List<T> getDataUsing(IExternalDataConnectionService eds, RegionsInDashboard region) {
 		Logger log = LoggerFactory.getLogger(this.getClass().getSimpleName());
 		log.info(this.getClass().getSimpleName() + " is about to call makeDataListFromExternalSource with " + eds.toString());
 		return eds.makeDataListFromExternalSource(region.name());

--- a/src/main/java/com/royware/corona/dashboard/services/data/external/getters/WorldCountryDataGetter.java
+++ b/src/main/java/com/royware/corona/dashboard/services/data/external/getters/WorldCountryDataGetter.java
@@ -1,0 +1,21 @@
+package com.royware.corona.dashboard.services.data.external.getters;
+
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.royware.corona.dashboard.enums.regions.RegionsInDashboard;
+import com.royware.corona.dashboard.interfaces.data.IExternalDataConnectionService;
+import com.royware.corona.dashboard.interfaces.data.external.IExternalDataGetter;
+import com.royware.corona.dashboard.interfaces.model.CanonicalCaseDeathData;
+
+public class WorldCountryDataGetter implements IExternalDataGetter {
+
+	@Override
+	public <T extends CanonicalCaseDeathData> List<T> getDataUsing(IExternalDataConnectionService eds, RegionsInDashboard region) {
+		Logger log = LoggerFactory.getLogger(this.getClass().getSimpleName());
+		log.info(this.getClass().getSimpleName() + " is about to call makeDataListFromExternalSource with " + eds.toString());
+		return eds.makeDataListFromExternalSource(region.name());
+	}
+}

--- a/src/main/java/com/royware/corona/dashboard/services/data/us/ExternalDataServiceMultiStateImpl.java
+++ b/src/main/java/com/royware/corona/dashboard/services/data/us/ExternalDataServiceMultiStateImpl.java
@@ -8,19 +8,19 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
-import com.royware.corona.dashboard.interfaces.data.ExternalDataService;
+import com.royware.corona.dashboard.interfaces.data.IExternalDataConnectionService;
 import com.royware.corona.dashboard.model.data.us.UnitedStatesData;
 
 /**
  * Provides service methods for getting dashboard data from external sources
  */
 @Component("multiState")
-public class ExternalDataServiceMultiStateImpl implements ExternalDataService {
+public class ExternalDataServiceMultiStateImpl implements IExternalDataConnectionService {
 	private static final Logger log = LoggerFactory.getLogger(ExternalDataServiceMultiStateImpl.class);
 	
 	@Autowired
 	@Qualifier(value = "singleState")
-	private ExternalDataService singleStateDataService;
+	private IExternalDataConnectionService singleStateDataService;
 	
 	@SuppressWarnings("unchecked")
 	@Override

--- a/src/main/java/com/royware/corona/dashboard/services/data/us/ExternalDataServiceSingleStateImpl.java
+++ b/src/main/java/com/royware/corona/dashboard/services/data/us/ExternalDataServiceSingleStateImpl.java
@@ -14,7 +14,7 @@ import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 
 import com.royware.corona.dashboard.enums.data.DataUrls;
-import com.royware.corona.dashboard.interfaces.data.ExternalDataService;
+import com.royware.corona.dashboard.interfaces.data.IExternalDataConnectionService;
 import com.royware.corona.dashboard.model.data.us.CaseDeathVaccData_CovidActNow;
 import com.royware.corona.dashboard.model.data.us.CaseDeathVaccTimeSeries_CovActNow;
 import com.royware.corona.dashboard.model.data.us.HospitalDataCDC;
@@ -24,7 +24,7 @@ import com.royware.corona.dashboard.model.data.us.UnitedStatesData;
  * Provides service methods for getting dashboard data from external sources
  */
 @Component("singleState")
-public class ExternalDataServiceSingleStateImpl implements ExternalDataService {
+public class ExternalDataServiceSingleStateImpl implements IExternalDataConnectionService {
 	@Autowired
 	private RestTemplate restTemplate;
 	

--- a/src/main/java/com/royware/corona/dashboard/services/data/us/ExternalDataServiceUSAExcludingStateImpl.java
+++ b/src/main/java/com/royware/corona/dashboard/services/data/us/ExternalDataServiceUSAExcludingStateImpl.java
@@ -9,21 +9,21 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 import com.royware.corona.dashboard.enums.data.CacheKeys;
-import com.royware.corona.dashboard.interfaces.data.ExternalDataService;
+import com.royware.corona.dashboard.interfaces.data.IExternalDataConnectionService;
 import com.royware.corona.dashboard.model.data.us.UnitedStatesData;
 
 /**
  * Provides service methods for getting dashboard data from external sources
  */
 @Component("usExcludingState")
-public class ExternalDataServiceUSAExcludingStateImpl implements ExternalDataService {
+public class ExternalDataServiceUSAExcludingStateImpl implements IExternalDataConnectionService {
 	@Autowired
 	@Qualifier(value = "us")
-	private ExternalDataService usDataService;
+	private IExternalDataConnectionService usDataService;
 	
 	@Autowired
 	@Qualifier(value = "singleState")
-	private ExternalDataService stateDataService;
+	private IExternalDataConnectionService stateDataService;
 	
 	private static final Logger log = LoggerFactory.getLogger(ExternalDataServiceUSAExcludingStateImpl.class);
 	

--- a/src/main/java/com/royware/corona/dashboard/services/data/us/ExternalDataServiceUSAImpl.java
+++ b/src/main/java/com/royware/corona/dashboard/services/data/us/ExternalDataServiceUSAImpl.java
@@ -9,9 +9,9 @@ import org.springframework.cache.Cache.ValueWrapper;
 import org.springframework.cache.concurrent.ConcurrentMapCache;
 import org.springframework.stereotype.Component;
 
-import com.royware.corona.dashboard.interfaces.dashboard.DashboardConfigService;
+import com.royware.corona.dashboard.interfaces.dashboard.IDashboardConfigService;
 import com.royware.corona.dashboard.interfaces.data.IExternalDataConnectionService;
-import com.royware.corona.dashboard.interfaces.data.ExternalDataServiceFactory;
+import com.royware.corona.dashboard.interfaces.data.IExternalDataServiceFactory;
 import com.royware.corona.dashboard.interfaces.data.IMultiRegionExternalDataService;
 import com.royware.corona.dashboard.model.data.us.UnitedStatesData;
 import com.royware.corona.dashboard.services.data.cache.CacheManagerProvider;
@@ -26,7 +26,7 @@ public class ExternalDataServiceUSAImpl implements IExternalDataConnectionServic
 	private IMultiRegionExternalDataService multiRegionDataService;
 	
 	@Autowired
-	private ExternalDataServiceFactory dataService;
+	private IExternalDataServiceFactory dataService;
 
 	//Pull data directly from the cache always
 	@SuppressWarnings("unchecked")
@@ -37,7 +37,7 @@ public class ExternalDataServiceUSAImpl implements IExternalDataConnectionServic
 		if(usaData == null || usaData.isEmpty()) {
 			log.info("US Data not in cache. Getting the USA data from its source (via multi-region).");
 			usaData = multiRegionDataService.getMultiRegionDataFromExternalSource(
-					DashboardConfigService.ALL_STATES_AS_CSV,
+					IDashboardConfigService.ALL_STATES_AS_CSV,
 					dataService.getExternalDataService("MULTI")
 			);
 		} else {

--- a/src/main/java/com/royware/corona/dashboard/services/data/us/ExternalDataServiceUSAImpl.java
+++ b/src/main/java/com/royware/corona/dashboard/services/data/us/ExternalDataServiceUSAImpl.java
@@ -10,14 +10,14 @@ import org.springframework.cache.concurrent.ConcurrentMapCache;
 import org.springframework.stereotype.Component;
 
 import com.royware.corona.dashboard.interfaces.dashboard.DashboardConfigService;
-import com.royware.corona.dashboard.interfaces.data.ExternalDataService;
+import com.royware.corona.dashboard.interfaces.data.IExternalDataConnectionService;
 import com.royware.corona.dashboard.interfaces.data.ExternalDataServiceFactory;
 import com.royware.corona.dashboard.interfaces.data.IMultiRegionExternalDataService;
 import com.royware.corona.dashboard.model.data.us.UnitedStatesData;
 import com.royware.corona.dashboard.services.data.cache.CacheManagerProvider;
 
 @Component("us")
-public class ExternalDataServiceUSAImpl implements ExternalDataService {
+public class ExternalDataServiceUSAImpl implements IExternalDataConnectionService {
 	
 	private ConcurrentMapCache cacheManager;
 	private static final Logger log = LoggerFactory.getLogger(ExternalDataServiceUSAImpl.class);

--- a/src/main/java/com/royware/corona/dashboard/services/data/us/MultiRegionExternalDataServiceImpl.java
+++ b/src/main/java/com/royware/corona/dashboard/services/data/us/MultiRegionExternalDataServiceImpl.java
@@ -14,7 +14,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import com.royware.corona.dashboard.enums.regions.UsGeoRegions;
-import com.royware.corona.dashboard.enums.regions.RegionsData;
+import com.royware.corona.dashboard.enums.regions.RegionsInDashboard;
 import com.royware.corona.dashboard.interfaces.data.IExternalDataConnectionService;
 import com.royware.corona.dashboard.interfaces.data.IMultiRegionExternalDataService;
 import com.royware.corona.dashboard.interfaces.data.IMultiRegionListStitcher;
@@ -69,7 +69,7 @@ public class MultiRegionExternalDataServiceImpl implements IMultiRegionExternalD
 		//Split the full region name into individual states, then iterate through the states and sum their populations
 		int sumPop = 0;
 		for(String state : arrayOfStates) {
-			sumPop += RegionsData.valueOf(state).getRegionData().getPopulation();
+			sumPop += RegionsInDashboard.valueOf(state).getPopulation();
 		}
 		return sumPop;
 	}

--- a/src/main/java/com/royware/corona/dashboard/services/data/us/MultiRegionExternalDataServiceImpl.java
+++ b/src/main/java/com/royware/corona/dashboard/services/data/us/MultiRegionExternalDataServiceImpl.java
@@ -15,7 +15,7 @@ import org.springframework.stereotype.Component;
 
 import com.royware.corona.dashboard.enums.regions.UsGeoRegions;
 import com.royware.corona.dashboard.enums.regions.RegionsData;
-import com.royware.corona.dashboard.interfaces.data.ExternalDataService;
+import com.royware.corona.dashboard.interfaces.data.IExternalDataConnectionService;
 import com.royware.corona.dashboard.interfaces.data.IMultiRegionExternalDataService;
 import com.royware.corona.dashboard.interfaces.data.IMultiRegionListStitcher;
 import com.royware.corona.dashboard.model.data.us.UnitedStatesData;
@@ -83,7 +83,7 @@ public class MultiRegionExternalDataServiceImpl implements IMultiRegionExternalD
 	}
 	
 	@Override
-	public List<UnitedStatesData> getMultiRegionDataFromExternalSource(String fullRegionName, ExternalDataService dataService) {
+	public List<UnitedStatesData> getMultiRegionDataFromExternalSource(String fullRegionName, IExternalDataConnectionService dataService) {
 		List<UnitedStatesData> multiRegionDataList = new ArrayList<>();
 		Map<String, List<UnitedStatesData>> mapOfStateDataLists = new HashMap<String, List<UnitedStatesData>>();
 		

--- a/src/main/java/com/royware/corona/dashboard/services/data/us/MultiRegionListStitcherImpl.java
+++ b/src/main/java/com/royware/corona/dashboard/services/data/us/MultiRegionListStitcherImpl.java
@@ -12,7 +12,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 import com.royware.corona.dashboard.enums.data.DataFields;
-import com.royware.corona.dashboard.interfaces.data.ExternalDataService;
+import com.royware.corona.dashboard.interfaces.data.IExternalDataConnectionService;
 import com.royware.corona.dashboard.interfaces.data.IMultiRegionListStitcher;
 import com.royware.corona.dashboard.model.data.us.UnitedStatesData;
 
@@ -101,7 +101,7 @@ public class MultiRegionListStitcherImpl implements IMultiRegionListStitcher {
 	}
 
 	@Override
-	public Map<String, List<UnitedStatesData>> makeMapOfStateDataLists(ExternalDataService dataService, String[] states) {
+	public Map<String, List<UnitedStatesData>> makeMapOfStateDataLists(IExternalDataConnectionService dataService, String[] states) {
 		Map<String, List<UnitedStatesData>> stateDataLists = new HashMap<>();
 		
 		//Make a map where the key is the state and the value is the list of data for the state

--- a/src/main/java/com/royware/corona/dashboard/services/data/world/ExternalDataServiceSingleCountryImpl.java
+++ b/src/main/java/com/royware/corona/dashboard/services/data/world/ExternalDataServiceSingleCountryImpl.java
@@ -13,7 +13,7 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 import com.royware.corona.dashboard.enums.data.CacheKeys;
-import com.royware.corona.dashboard.interfaces.data.ExternalDataService;
+import com.royware.corona.dashboard.interfaces.data.IExternalDataConnectionService;
 import com.royware.corona.dashboard.model.data.world.WorldData;
 
 /**
@@ -21,10 +21,10 @@ import com.royware.corona.dashboard.model.data.world.WorldData;
  */
 
 @Component("singleCountry")
-public class ExternalDataServiceSingleCountryImpl implements ExternalDataService {
+public class ExternalDataServiceSingleCountryImpl implements IExternalDataConnectionService {
 	@Autowired
 	@Qualifier(value = "world")
-	private ExternalDataService worldDataService;
+	private IExternalDataConnectionService worldDataService;
 	
 	private static final int MINIMUM_NUMBER_OF_DAILY_CASES_FOR_INCLUSION = 10;
 	private static final int MINIMUM_TOTAL_CASES_FOR_INCLUSION = 100;

--- a/src/main/java/com/royware/corona/dashboard/services/data/world/ExternalDataServiceWorldImpl.java
+++ b/src/main/java/com/royware/corona/dashboard/services/data/world/ExternalDataServiceWorldImpl.java
@@ -25,7 +25,7 @@ import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.royware.corona.dashboard.enums.data.DataUrls;
 import com.royware.corona.dashboard.interfaces.data.IExternalDataConnectionService;
-import com.royware.corona.dashboard.interfaces.data.WorldDataServiceCaller;
+import com.royware.corona.dashboard.interfaces.data.IWorldDataServiceCaller;
 import com.royware.corona.dashboard.model.data.world.WorldData;
 import com.royware.corona.dashboard.model.data.world.WorldDataOWID;
 import com.royware.corona.dashboard.model.data.world.WorldDataSourceEuroCDC;
@@ -33,7 +33,7 @@ import com.royware.corona.dashboard.model.data.world.WorldDataSourceOurWorldInDa
 import com.royware.corona.dashboard.services.data.cache.CacheManagerProvider;
 
 @Component
-public class ExternalDataServiceWorldImpl implements IExternalDataConnectionService, WorldDataServiceCaller {
+public class ExternalDataServiceWorldImpl implements IExternalDataConnectionService, IWorldDataServiceCaller {
 	@Autowired
 	private RestTemplate restTemplate;
 	

--- a/src/main/java/com/royware/corona/dashboard/services/data/world/ExternalDataServiceWorldImpl.java
+++ b/src/main/java/com/royware/corona/dashboard/services/data/world/ExternalDataServiceWorldImpl.java
@@ -24,7 +24,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.royware.corona.dashboard.enums.data.DataUrls;
-import com.royware.corona.dashboard.interfaces.data.ExternalDataService;
+import com.royware.corona.dashboard.interfaces.data.IExternalDataConnectionService;
 import com.royware.corona.dashboard.interfaces.data.WorldDataServiceCaller;
 import com.royware.corona.dashboard.model.data.world.WorldData;
 import com.royware.corona.dashboard.model.data.world.WorldDataOWID;
@@ -33,7 +33,7 @@ import com.royware.corona.dashboard.model.data.world.WorldDataSourceOurWorldInDa
 import com.royware.corona.dashboard.services.data.cache.CacheManagerProvider;
 
 @Component
-public class ExternalDataServiceWorldImpl implements ExternalDataService, WorldDataServiceCaller {
+public class ExternalDataServiceWorldImpl implements IExternalDataConnectionService, WorldDataServiceCaller {
 	@Autowired
 	private RestTemplate restTemplate;
 	


### PR DESCRIPTION
Refactored so that RegionsData enum no longer has responsibility for getting region external data or returning the population. Created a RegionsInDashboard enum that has the population and full name for each region in the dashboard (countries and U.S. states). Moved the getting of external data and the getting of region demographic data to separate simple factories.

Also refactored all interfaces to begin with "I" for consistency.