### PR TITLE
Graph spikes

### DIFF
--- a/src/main/java/com/royware/corona/dashboard/config/ApplicationStartup.java
+++ b/src/main/java/com/royware/corona/dashboard/config/ApplicationStartup.java
@@ -31,8 +31,10 @@ public class ApplicationStartup {
 	public void contextRefreshedEvent() {
 		log.info("Application has successfully started in environment: {}", env.getProperty("ENVIRONMENT"));
 		log.info("About to initialize the WORLD cache with cacheActions object of class: {}", cacheActionsWorld.getClass().getSimpleName());
+		cacheActionsWorld.setCleanData(false);
 		cacheActionsWorld.populateCacheFromSource(CacheKeys.CACHE_KEY_WORLD.getName());
 		log.info("About to initialize the USA cache with cacheActions object of class: {}", cacheActionsUS.getClass().getSimpleName());
+		cacheActionsUS.setCleanData(Boolean.parseBoolean(env.getProperty("corona.filter.data")));
 		cacheActionsUS.populateCacheFromSource(CacheKeys.CACHE_KEY_US.getName());
 	}
 }

--- a/src/main/java/com/royware/corona/dashboard/enums/data/ChartListConstants.java
+++ b/src/main/java/com/royware/corona/dashboard/enums/data/ChartListConstants.java
@@ -1,16 +1,17 @@
 package com.royware.corona.dashboard.enums.data;
 
-public enum MovingAverageSizes {
+public enum ChartListConstants {
 	MOVING_AVERAGE_SIZE(4),
 	CURRENT_POSITIVES_QUEUE_SIZE_PRIMARY(7),
 	CURRENT_POSITIVES_QUEUE_SIZE_SECONDARY(10),
 	CURRENT_DEATHS_QUEUE_SIZE_PRIMARY(7),
 	CURRENT_DEATHS_QUEUE_SIZE_SECONDARY(10),
-	PER_CAPITA_BASIS(100000);
+	PER_CAPITA_BASIS(100000),
+	JUMP_FILTER_PERCENT_THRESHOLD_PCT(50);
 	
 	public final Integer size;
 	
-	private MovingAverageSizes(Integer size) {
+	private ChartListConstants(Integer size) {
 		this.size = size;
 	}
 	

--- a/src/main/java/com/royware/corona/dashboard/enums/data/QuantityTypes.java
+++ b/src/main/java/com/royware/corona/dashboard/enums/data/QuantityTypes.java
@@ -1,0 +1,8 @@
+package com.royware.corona.dashboard.enums.data;
+
+public enum QuantityTypes {
+	CASES,
+	DEATHS,
+	VACC,
+	HOSP,
+}

--- a/src/main/java/com/royware/corona/dashboard/enums/data/QuantityTypes.java
+++ b/src/main/java/com/royware/corona/dashboard/enums/data/QuantityTypes.java
@@ -1,8 +1,0 @@
-package com.royware.corona.dashboard.enums.data;
-
-public enum QuantityTypes {
-	CASES,
-	DEATHS,
-	VACC,
-	HOSP,
-}

--- a/src/main/java/com/royware/corona/dashboard/interfaces/data/ICacheActions.java
+++ b/src/main/java/com/royware/corona/dashboard/interfaces/data/ICacheActions.java
@@ -14,4 +14,5 @@ public interface ICacheActions {
 	public void evictCache();
 	public <T extends ICanonicalCaseDeathData> void populateCacheFromDataList(String cacheName, List<T> newCacheData);
 	public void populateCacheFromSource(String cacheName);
+	public void setCleanData(boolean cleanData);
 }

--- a/src/main/java/com/royware/corona/dashboard/interfaces/data/IExternalDataConnectionService.java
+++ b/src/main/java/com/royware/corona/dashboard/interfaces/data/IExternalDataConnectionService.java
@@ -8,4 +8,5 @@ public interface IExternalDataConnectionService {
 	public static final int US_CUTOFF_DATE = 20200304;
 	
 	public <T extends ICanonicalCaseDeathData> List<T> makeDataListFromExternalSource(String cacheKey);
+	public void setCleanNegativeChangesFromTotals(boolean cleanNegativeChangesFromTotals);
 }

--- a/src/main/java/com/royware/corona/dashboard/interfaces/data/IMultiRegionExternalDataService.java
+++ b/src/main/java/com/royware/corona/dashboard/interfaces/data/IMultiRegionExternalDataService.java
@@ -11,4 +11,5 @@ public interface IMultiRegionExternalDataService {
 	public String getStatesFromMultiRegionString(String region);
 	public int getMultiRegionPopulation(String fullRegionName);
 	public List<UnitedStatesData> getMultiRegionDataFromExternalSource(String fullRegionName, IExternalDataConnectionService dataService);
+	public void setCleanNegativeChangesFromTotals(boolean cleanNegativeChangesFromTotals);
 }

--- a/src/main/java/com/royware/corona/dashboard/interfaces/data/IMultiRegionListStitcher.java
+++ b/src/main/java/com/royware/corona/dashboard/interfaces/data/IMultiRegionListStitcher.java
@@ -13,5 +13,7 @@ public interface IMultiRegionListStitcher {
 	List<UnitedStatesData> stitchMultiStateListsIntoOneList(Map<String, List<UnitedStatesData>> mapOfStateDataLists, String[] states);
 
 	Map<String, List<UnitedStatesData>> makeMapOfStateDataLists(IExternalDataConnectionService dataService, String[] states);
+	
+	public void setCleanNegativeChangesFromTotals(boolean cleanNegativeChangesFromTotals);
 
 }

--- a/src/main/java/com/royware/corona/dashboard/services/chart/config/makers/ChartConfigAccelerationOfCases.java
+++ b/src/main/java/com/royware/corona/dashboard/services/chart/config/makers/ChartConfigAccelerationOfCases.java
@@ -3,7 +3,7 @@ package com.royware.corona.dashboard.services.chart.config.makers;
 import java.util.List;
 import java.util.Map;
 
-import com.royware.corona.dashboard.enums.data.MovingAverageSizes;
+import com.royware.corona.dashboard.enums.data.ChartListConstants;
 import com.royware.corona.dashboard.interfaces.chartconfig.IChartConfigMaker;
 import com.royware.corona.dashboard.model.dashboard.DashboardChartConfig;
 
@@ -20,7 +20,7 @@ public class ChartConfigAccelerationOfCases implements IChartConfigMaker {
 		chartConfig.setxAxisTitle("Days Since Cases > 0");
 		chartConfig.setyAxisTitle("Percent Change in Rate of New Positives");
 		chartConfig.setDataSeries1Name("Acceleration of Positives");
-		chartConfig.setDataSeries2Name(MovingAverageSizes.MOVING_AVERAGE_SIZE.getValue() + "-day Moving Average");
+		chartConfig.setDataSeries2Name(ChartListConstants.MOVING_AVERAGE_SIZE.getValue() + "-day Moving Average");
 
 		chartConfig.setChartType("scatter");
 		chartConfig.setyAxisNumberSuffix("%");

--- a/src/main/java/com/royware/corona/dashboard/services/chart/config/makers/ChartConfigAccelerationOfDeaths.java
+++ b/src/main/java/com/royware/corona/dashboard/services/chart/config/makers/ChartConfigAccelerationOfDeaths.java
@@ -3,7 +3,7 @@ package com.royware.corona.dashboard.services.chart.config.makers;
 import java.util.List;
 import java.util.Map;
 
-import com.royware.corona.dashboard.enums.data.MovingAverageSizes;
+import com.royware.corona.dashboard.enums.data.ChartListConstants;
 import com.royware.corona.dashboard.interfaces.chartconfig.IChartConfigMaker;
 import com.royware.corona.dashboard.model.dashboard.DashboardChartConfig;
 
@@ -23,7 +23,7 @@ public class ChartConfigAccelerationOfDeaths implements IChartConfigMaker {
 		chartConfig.setxAxisTitle("Days Since Deaths > 0");
 		chartConfig.setyAxisTitle("Percent Change in Rate of New Deaths");
 		chartConfig.setDataSeries1Name("Acceleration of Deaths");
-		chartConfig.setDataSeries2Name(MovingAverageSizes.MOVING_AVERAGE_SIZE.getValue() + "-day Moving Average");
+		chartConfig.setDataSeries2Name(ChartListConstants.MOVING_AVERAGE_SIZE.getValue() + "-day Moving Average");
 		
 		chartConfig.setyAxisNumberSuffix("%");
 		chartConfig.setxAxisPosition("bottom");

--- a/src/main/java/com/royware/corona/dashboard/services/chart/config/makers/ChartConfigCasesByTime.java
+++ b/src/main/java/com/royware/corona/dashboard/services/chart/config/makers/ChartConfigCasesByTime.java
@@ -3,7 +3,7 @@ package com.royware.corona.dashboard.services.chart.config.makers;
 import java.util.List;
 import java.util.Map;
 
-import com.royware.corona.dashboard.enums.data.MovingAverageSizes;
+import com.royware.corona.dashboard.enums.data.ChartListConstants;
 import com.royware.corona.dashboard.interfaces.chartconfig.IChartConfigMaker;
 import com.royware.corona.dashboard.model.dashboard.DashboardChartConfig;
 
@@ -17,7 +17,7 @@ public class ChartConfigCasesByTime implements IChartConfigMaker {
 		chartConfig.setxAxisTitle("Days Since Cases > 0");
 		chartConfig.setyAxisTitle("Total Positive Tests");
 		chartConfig.setDataSeries1Name("Total Positives");
-		chartConfig.setDataSeries2Name(MovingAverageSizes.MOVING_AVERAGE_SIZE.getValue() + "-day Moving Average of New Positives");
+		chartConfig.setDataSeries2Name(ChartListConstants.MOVING_AVERAGE_SIZE.getValue() + "-day Moving Average of New Positives");
 
 		chartConfig.setChartType("scatter");
 		chartConfig.setyAxisNumberSuffix("");

--- a/src/main/java/com/royware/corona/dashboard/services/chart/config/makers/ChartConfigCumulativeHospitalizationsByTime.java
+++ b/src/main/java/com/royware/corona/dashboard/services/chart/config/makers/ChartConfigCumulativeHospitalizationsByTime.java
@@ -3,7 +3,7 @@ package com.royware.corona.dashboard.services.chart.config.makers;
 import java.util.List;
 import java.util.Map;
 
-import com.royware.corona.dashboard.enums.data.MovingAverageSizes;
+import com.royware.corona.dashboard.enums.data.ChartListConstants;
 import com.royware.corona.dashboard.interfaces.chartconfig.IChartConfigMaker;
 import com.royware.corona.dashboard.model.dashboard.DashboardChartConfig;
 
@@ -22,7 +22,7 @@ public class ChartConfigCumulativeHospitalizationsByTime implements IChartConfig
 		chartConfig.setxAxisTitle("Days Since Cases > 0");
 		chartConfig.setyAxisTitle("Cumulative Hospitalizations");
 		chartConfig.setDataSeries1Name("Cumulative Hospitalizations");
-		chartConfig.setDataSeries2Name(MovingAverageSizes.MOVING_AVERAGE_SIZE.getValue() + "-day Moving Average of New Hospitalizations");
+		chartConfig.setDataSeries2Name(ChartListConstants.MOVING_AVERAGE_SIZE.getValue() + "-day Moving Average of New Hospitalizations");
 		
 		chartConfig.setyAxisNumberSuffix("");
 		chartConfig.setxAxisPosition("bottom");

--- a/src/main/java/com/royware/corona/dashboard/services/chart/config/makers/ChartConfigCurrentHospitalizationsByTime.java
+++ b/src/main/java/com/royware/corona/dashboard/services/chart/config/makers/ChartConfigCurrentHospitalizationsByTime.java
@@ -3,7 +3,7 @@ package com.royware.corona.dashboard.services.chart.config.makers;
 import java.util.List;
 import java.util.Map;
 
-import com.royware.corona.dashboard.enums.data.MovingAverageSizes;
+import com.royware.corona.dashboard.enums.data.ChartListConstants;
 import com.royware.corona.dashboard.interfaces.chartconfig.IChartConfigMaker;
 import com.royware.corona.dashboard.model.dashboard.DashboardChartConfig;
 
@@ -22,7 +22,7 @@ public class ChartConfigCurrentHospitalizationsByTime implements IChartConfigMak
 		chartConfig.setxAxisTitle("Days Since Cases > 0");
 		chartConfig.setyAxisTitle("Current Hospitalizations");
 		chartConfig.setDataSeries1Name("Current Hospitalizations");
-		chartConfig.setDataSeries2Name(MovingAverageSizes.MOVING_AVERAGE_SIZE.getValue() + "-day Moving Average of New Hospitalizations");
+		chartConfig.setDataSeries2Name(ChartListConstants.MOVING_AVERAGE_SIZE.getValue() + "-day Moving Average of New Hospitalizations");
 		
 		chartConfig.setyAxisNumberSuffix("");
 		chartConfig.setxAxisPosition("bottom");

--- a/src/main/java/com/royware/corona/dashboard/services/chart/config/makers/ChartConfigDeathsByTime.java
+++ b/src/main/java/com/royware/corona/dashboard/services/chart/config/makers/ChartConfigDeathsByTime.java
@@ -3,7 +3,7 @@ package com.royware.corona.dashboard.services.chart.config.makers;
 import java.util.List;
 import java.util.Map;
 
-import com.royware.corona.dashboard.enums.data.MovingAverageSizes;
+import com.royware.corona.dashboard.enums.data.ChartListConstants;
 import com.royware.corona.dashboard.interfaces.chartconfig.IChartConfigMaker;
 import com.royware.corona.dashboard.model.dashboard.DashboardChartConfig;
 
@@ -22,7 +22,7 @@ public class ChartConfigDeathsByTime implements IChartConfigMaker {
 		chartConfig.setxAxisTitle("Days Since Deaths > 0");
 		chartConfig.setyAxisTitle("Total Deaths");
 		chartConfig.setDataSeries1Name("Total Deaths");
-		chartConfig.setDataSeries2Name(MovingAverageSizes.MOVING_AVERAGE_SIZE.getValue() + "-day Moving Average of New Deaths");
+		chartConfig.setDataSeries2Name(ChartListConstants.MOVING_AVERAGE_SIZE.getValue() + "-day Moving Average of New Deaths");
 		
 		chartConfig.setyAxisNumberSuffix("");
 		chartConfig.setxAxisPosition("bottom");

--- a/src/main/java/com/royware/corona/dashboard/services/chart/config/makers/ChartConfigRateOfChangeOfCases.java
+++ b/src/main/java/com/royware/corona/dashboard/services/chart/config/makers/ChartConfigRateOfChangeOfCases.java
@@ -3,7 +3,7 @@ package com.royware.corona.dashboard.services.chart.config.makers;
 import java.util.List;
 import java.util.Map;
 
-import com.royware.corona.dashboard.enums.data.MovingAverageSizes;
+import com.royware.corona.dashboard.enums.data.ChartListConstants;
 import com.royware.corona.dashboard.interfaces.chartconfig.IChartConfigMaker;
 import com.royware.corona.dashboard.model.dashboard.DashboardChartConfig;
 
@@ -20,7 +20,7 @@ public class ChartConfigRateOfChangeOfCases implements IChartConfigMaker {
 		chartConfig.setxAxisTitle("Days Since Cases > 0");
 		chartConfig.setyAxisTitle("Percent Change in New Positives");
 		chartConfig.setDataSeries1Name("% Change in Positives");
-		chartConfig.setDataSeries2Name(MovingAverageSizes.MOVING_AVERAGE_SIZE.getValue() + "-day Moving Average");
+		chartConfig.setDataSeries2Name(ChartListConstants.MOVING_AVERAGE_SIZE.getValue() + "-day Moving Average");
 
 		chartConfig.setChartType("scatter");
 		chartConfig.setyAxisNumberSuffix("%");

--- a/src/main/java/com/royware/corona/dashboard/services/chart/config/makers/ChartConfigRateOfChangeOfDeaths.java
+++ b/src/main/java/com/royware/corona/dashboard/services/chart/config/makers/ChartConfigRateOfChangeOfDeaths.java
@@ -3,7 +3,7 @@ package com.royware.corona.dashboard.services.chart.config.makers;
 import java.util.List;
 import java.util.Map;
 
-import com.royware.corona.dashboard.enums.data.MovingAverageSizes;
+import com.royware.corona.dashboard.enums.data.ChartListConstants;
 import com.royware.corona.dashboard.interfaces.chartconfig.IChartConfigMaker;
 import com.royware.corona.dashboard.model.dashboard.DashboardChartConfig;
 
@@ -22,7 +22,7 @@ public class ChartConfigRateOfChangeOfDeaths implements IChartConfigMaker {
 		chartConfig.setxAxisTitle("Days Since Deaths > 0");
 		chartConfig.setyAxisTitle("Percent Change in New Deaths");
 		chartConfig.setDataSeries1Name("% change in deaths");
-		chartConfig.setDataSeries2Name(MovingAverageSizes.MOVING_AVERAGE_SIZE.getValue() + "-day Moving Average");
+		chartConfig.setDataSeries2Name(ChartListConstants.MOVING_AVERAGE_SIZE.getValue() + "-day Moving Average");
 		
 		chartConfig.setyAxisNumberSuffix("%");
 		chartConfig.setxAxisPosition("bottom");

--- a/src/main/java/com/royware/corona/dashboard/services/chart/config/makers/ChartConfigRatioOfCasesToTestsByTime.java
+++ b/src/main/java/com/royware/corona/dashboard/services/chart/config/makers/ChartConfigRatioOfCasesToTestsByTime.java
@@ -3,7 +3,7 @@ package com.royware.corona.dashboard.services.chart.config.makers;
 import java.util.List;
 import java.util.Map;
 
-import com.royware.corona.dashboard.enums.data.MovingAverageSizes;
+import com.royware.corona.dashboard.enums.data.ChartListConstants;
 import com.royware.corona.dashboard.interfaces.chartconfig.IChartConfigMaker;
 import com.royware.corona.dashboard.model.dashboard.DashboardChartConfig;
 
@@ -22,7 +22,7 @@ public class ChartConfigRatioOfCasesToTestsByTime implements IChartConfigMaker {
 		chartConfig.setxAxisTitle("Days Since Cases > 0");
 		chartConfig.setyAxisTitle("Ratio of Positives to Tests, %");
 		chartConfig.setDataSeries1Name("% Positive per Test");
-		chartConfig.setDataSeries2Name(MovingAverageSizes.MOVING_AVERAGE_SIZE.getValue() + "-day Moving Average");
+		chartConfig.setDataSeries2Name(ChartListConstants.MOVING_AVERAGE_SIZE.getValue() + "-day Moving Average");
 		
 		chartConfig.setyAxisNumberSuffix("%");
 		chartConfig.setxAxisPosition("bottom");

--- a/src/main/java/com/royware/corona/dashboard/services/chart/config/makers/ChartConfigTestsByTime.java
+++ b/src/main/java/com/royware/corona/dashboard/services/chart/config/makers/ChartConfigTestsByTime.java
@@ -3,7 +3,7 @@ package com.royware.corona.dashboard.services.chart.config.makers;
 import java.util.List;
 import java.util.Map;
 
-import com.royware.corona.dashboard.enums.data.MovingAverageSizes;
+import com.royware.corona.dashboard.enums.data.ChartListConstants;
 import com.royware.corona.dashboard.interfaces.chartconfig.IChartConfigMaker;
 import com.royware.corona.dashboard.model.dashboard.DashboardChartConfig;
 
@@ -22,7 +22,7 @@ public class ChartConfigTestsByTime implements IChartConfigMaker {
 		chartConfig.setxAxisTitle("Days Since Cases > 0");
 		chartConfig.setyAxisTitle("Total Tests");
 		chartConfig.setDataSeries1Name("Total Tests");
-		chartConfig.setDataSeries2Name(MovingAverageSizes.MOVING_AVERAGE_SIZE.getValue() + "-day Moving Average of New Tests");
+		chartConfig.setDataSeries2Name(ChartListConstants.MOVING_AVERAGE_SIZE.getValue() + "-day Moving Average of New Tests");
 		
 		chartConfig.setyAxisNumberSuffix("");
 		chartConfig.setxAxisPosition("bottom");

--- a/src/main/java/com/royware/corona/dashboard/services/chart/config/makers/ChartConfigTotalCurrentCases.java
+++ b/src/main/java/com/royware/corona/dashboard/services/chart/config/makers/ChartConfigTotalCurrentCases.java
@@ -4,7 +4,7 @@ import java.text.NumberFormat;
 import java.util.List;
 import java.util.Map;
 
-import com.royware.corona.dashboard.enums.data.MovingAverageSizes;
+import com.royware.corona.dashboard.enums.data.ChartListConstants;
 import com.royware.corona.dashboard.interfaces.chartconfig.IChartConfigMaker;
 import com.royware.corona.dashboard.model.dashboard.DashboardChartConfig;
 
@@ -18,11 +18,11 @@ public class ChartConfigTotalCurrentCases implements IChartConfigMaker {
 
 		chartConfig.setChartTitle("Time History of Positivity Rate in " + region);
 		chartConfig.setxAxisTitle("Days Since Cases > 0");
-		chartConfig.setyAxisTitle("Positives per " + NumberFormat.getNumberInstance().format(MovingAverageSizes.PER_CAPITA_BASIS.getValue()));
-		chartConfig.setDataSeries1Name("Positives per " + NumberFormat.getNumberInstance().format(MovingAverageSizes.PER_CAPITA_BASIS.getValue())
-				+ " (Last " + MovingAverageSizes.CURRENT_POSITIVES_QUEUE_SIZE_PRIMARY.getValue() + " days)");
-		chartConfig.setDataSeries2Name("Positives per " + NumberFormat.getNumberInstance().format(MovingAverageSizes.PER_CAPITA_BASIS.getValue())
-				+ " (Last " + MovingAverageSizes.CURRENT_POSITIVES_QUEUE_SIZE_SECONDARY.getValue() + " days)");
+		chartConfig.setyAxisTitle("Positives per " + NumberFormat.getNumberInstance().format(ChartListConstants.PER_CAPITA_BASIS.getValue()));
+		chartConfig.setDataSeries1Name("Positives per " + NumberFormat.getNumberInstance().format(ChartListConstants.PER_CAPITA_BASIS.getValue())
+				+ " (Last " + ChartListConstants.CURRENT_POSITIVES_QUEUE_SIZE_PRIMARY.getValue() + " days)");
+		chartConfig.setDataSeries2Name("Positives per " + NumberFormat.getNumberInstance().format(ChartListConstants.PER_CAPITA_BASIS.getValue())
+				+ " (Last " + ChartListConstants.CURRENT_POSITIVES_QUEUE_SIZE_SECONDARY.getValue() + " days)");
 
 		chartConfig.setyAxisNumberSuffix("");
 		chartConfig.setxAxisPosition("bottom");

--- a/src/main/java/com/royware/corona/dashboard/services/chart/config/makers/ChartConfigVaccByTime.java
+++ b/src/main/java/com/royware/corona/dashboard/services/chart/config/makers/ChartConfigVaccByTime.java
@@ -3,7 +3,7 @@ package com.royware.corona.dashboard.services.chart.config.makers;
 import java.util.List;
 import java.util.Map;
 
-import com.royware.corona.dashboard.enums.data.MovingAverageSizes;
+import com.royware.corona.dashboard.enums.data.ChartListConstants;
 import com.royware.corona.dashboard.interfaces.chartconfig.IChartConfigMaker;
 import com.royware.corona.dashboard.model.dashboard.DashboardChartConfig;
 
@@ -22,7 +22,7 @@ public class ChartConfigVaccByTime implements IChartConfigMaker {
 		chartConfig.setxAxisTitle("Days Since Cases > 0");
 		chartConfig.setyAxisTitle("Total Vaccinations");
 		chartConfig.setDataSeries1Name("Total Vaccinations Completed");
-		chartConfig.setDataSeries2Name(MovingAverageSizes.MOVING_AVERAGE_SIZE.getValue() + "-day Moving Average of New Vacc");
+		chartConfig.setDataSeries2Name(ChartListConstants.MOVING_AVERAGE_SIZE.getValue() + "-day Moving Average of New Vacc");
 		
 		chartConfig.setyAxisNumberSuffix("");
 		chartConfig.setxAxisPosition("bottom");

--- a/src/main/java/com/royware/corona/dashboard/services/chart/list/factory/ChartListStore.java
+++ b/src/main/java/com/royware/corona/dashboard/services/chart/list/factory/ChartListStore.java
@@ -4,32 +4,23 @@ import java.util.List;
 import java.util.Map;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Component;
 
 import com.royware.corona.dashboard.enums.charts.ChartTypes;
 import com.royware.corona.dashboard.interfaces.chartlist.IChartListFactory;
 import com.royware.corona.dashboard.interfaces.chartlist.IChartListStore;
 import com.royware.corona.dashboard.interfaces.model.ICanonicalCaseDeathData;
-import com.royware.corona.dashboard.services.chart.list.makers.ChartListMakerUtilities;
 
 @Component
 public class ChartListStore implements IChartListStore {
 	@Autowired
 	private IChartListFactory chartListFactory;
 	
-	@Autowired
-	Environment config;
-	
 	@Override
 	public <T extends ICanonicalCaseDeathData> List<List<Map<Object, Object>>> produceChartListFromRegionData(
 			ChartTypes chartType,
 			List<T> regionData,
 			int regionPopulation) {
-		
-		if(Boolean.parseBoolean(config.getProperty("corona.filter.data"))) {
-			regionData = ChartListMakerUtilities.cleanDataList(regionData);
-		}		
 		
 		List<List<Map<Object, Object>>> toReturn = chartListFactory.create(chartType).makeListFrom(regionData, regionPopulation);
 		

--- a/src/main/java/com/royware/corona/dashboard/services/chart/list/factory/ChartListStore.java
+++ b/src/main/java/com/royware/corona/dashboard/services/chart/list/factory/ChartListStore.java
@@ -4,17 +4,22 @@ import java.util.List;
 import java.util.Map;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Component;
 
 import com.royware.corona.dashboard.enums.charts.ChartTypes;
 import com.royware.corona.dashboard.interfaces.chartlist.IChartListFactory;
 import com.royware.corona.dashboard.interfaces.chartlist.IChartListStore;
 import com.royware.corona.dashboard.interfaces.model.ICanonicalCaseDeathData;
+import com.royware.corona.dashboard.services.chart.list.makers.ChartListMakerUtilities;
 
 @Component
 public class ChartListStore implements IChartListStore {
 	@Autowired
 	private IChartListFactory chartListFactory;
+	
+	@Autowired
+	Environment config;
 	
 	@Override
 	public <T extends ICanonicalCaseDeathData> List<List<Map<Object, Object>>> produceChartListFromRegionData(
@@ -22,6 +27,12 @@ public class ChartListStore implements IChartListStore {
 			List<T> regionData,
 			int regionPopulation) {
 		
-		return chartListFactory.create(chartType).makeListFrom(regionData, regionPopulation);
+		if(Boolean.parseBoolean(config.getProperty("corona.filter.data"))) {
+			regionData = ChartListMakerUtilities.cleanDataList(regionData);
+		}		
+		
+		List<List<Map<Object, Object>>> toReturn = chartListFactory.create(chartType).makeListFrom(regionData, regionPopulation);
+		
+		return toReturn;
 	}	
 }

--- a/src/main/java/com/royware/corona/dashboard/services/chart/list/makers/ChartListMakerUtilities.java
+++ b/src/main/java/com/royware/corona/dashboard/services/chart/list/makers/ChartListMakerUtilities.java
@@ -1,7 +1,6 @@
 package com.royware.corona.dashboard.services.chart.list.makers;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -105,89 +104,4 @@ public class ChartListMakerUtilities {
 		
 		return movingAverageList;
 	}
-
-	public static List<Map<Object, Object>> filterJumpsFromList(List<Map<Object, Object>> toFilter) {
-		// Method that takes out "large" jumps from day to day that are the result of bad data in the provided data sets
-		List<Map<Object, Object>> filteredList = new ArrayList<>(toFilter);
-		
-		if(filteredList.size() == 2) {
-			return filteredList;
-		}
-		
-		List<Double> yValues = new ArrayList<>();
-		for (Map<Object, Object> yValue : filteredList) {
-			yValues.add(Double.valueOf(yValue.get("y").toString()));
-		}
-		Collections.sort(yValues);
-		
-		int size = yValues.size();
-		boolean sizeIsEven = size % 2 == 0;
-//		double median = 0.0;
-		double Q1 = 0.0;
-		double Q3 = 0.0;
-		int iMedian = size / 2;
-		int iQ1 = 0;
-		int iQ3 = 0;
-		double IQR = 0.0;
-		double upper = 0.0;
-		double lower = 0.0;
-		if(sizeIsEven) {
-			//median = (yValues.get(iMedian - 1) + yValues.get(iMedian)) / 2.0;
-			iQ1 = (iMedian - 1) / 2;
-			iQ3 = 3 * iMedian / 2;
-			Q1 = yValues.get(iQ1);
-			Q3 = yValues.get(iQ3);
-		} else {
-			//median = yValues.get(iMedian);
-			iQ1 = iMedian / 2;
-			iQ3 = 3 * iMedian / 2;
-			Q1 = (yValues.get(iQ1) + yValues.get(iQ1 - 1)) / 2.0;
-			Q3 = (yValues.get(iQ3) + yValues.get( + 1)) / 2.0;
-		}
-		IQR = Q3 - Q1;
-		upper = Q3 + 1.5 * IQR;
-		lower = Q1 - 1.5 * IQR;
-		
-		log.info("Making the filtered list with lower = " + lower + " and upper = " + upper);
-		
-//		double absChangePct = 0.0;
-//		Object prevDayValue = 0.0;
-		Double todayValue = 0.0;
-//		Object prevOriginalValue = 0.0;
-		
-		for(int dayIndex = 1; dayIndex < filteredList.size(); dayIndex++) {
-			// Look for outliers
-			todayValue = yValues.get(dayIndex);
-//			todayValue = Double.valueOf(filteredList.get(dayIndex).get("y").toString());
-			if(todayValue < lower || todayValue > upper) {
-				log.info("Removing value: " + todayValue);
-				filteredList.remove(dayIndex);
-			}
-			
-			// Look for data points where the change from the previous day is greater than X%			
-//			todayValue = Double.valueOf(filteredList.get(dayIndex).get("y").toString());
-//			prevDayValue = Double.valueOf(filteredList.get(dayIndex - 1).get("y").toString());
-//			prevOriginalValue = filteredList.get(dayIndex - 1).get("y");
-//			absChangePct = Math.abs(((Double)todayValue / (Double)prevDayValue - 1) * 100.0);
-//			if(absChangePct > ChartListConstants.JUMP_FILTER_PERCENT_THRESHOLD_PCT.getValue()) {
-//				log.info("Removing value: " + todayValue);
-//				filteredList.get(dayIndex).put("y", prevOriginalValue);
-//				continue;
-//			}
-		}
-			
-		return filteredList;
-	}
-	
-	public static <T extends ICanonicalCaseDeathData> List<T> cleanDataList(List<T> regionData) {
-		// Method will clean out data where the daily change in a total quantity is negative.
-		List<T> toReturn = new ArrayList<T>(regionData);
-		
-//		int today = toReturn.get(0).getTotalPositiveCases();
-//		for(int i = 1; i < toReturn.size(); i++) {
-//			
-//		}
-		
-		return toReturn;
-	}	
 }

--- a/src/main/java/com/royware/corona/dashboard/services/chart/list/makers/ChartListMakerUtilities.java
+++ b/src/main/java/com/royware/corona/dashboard/services/chart/list/makers/ChartListMakerUtilities.java
@@ -1,6 +1,7 @@
 package com.royware.corona.dashboard.services.chart.list.makers;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -8,7 +9,7 @@ import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.royware.corona.dashboard.enums.data.MovingAverageSizes;
+import com.royware.corona.dashboard.enums.data.ChartListConstants;
 import com.royware.corona.dashboard.interfaces.model.ICanonicalCaseDeathData;
 
 public class ChartListMakerUtilities {
@@ -82,14 +83,14 @@ public class ChartListMakerUtilities {
 		log.debug("Making the moving average...");
 		for(int dayIndex = startDayIndex; dayIndex < endDayIndex; dayIndex++) {
 			movingAverage = 0;
-			for(int d = dayIndex; d > dayIndex - MovingAverageSizes.MOVING_AVERAGE_SIZE.getValue(); d--) {
+			for(int d = dayIndex; d > dayIndex - ChartListConstants.MOVING_AVERAGE_SIZE.getValue(); d--) {
 				amountToAdd = dataMap.get(d);
-				if(!(Double.isNaN(amountToAdd) || Double.isInfinite(amountToAdd) || (int)amountToAdd == 100)) {
-					movingAverage += amountToAdd;
-					divisor++;
-				} else {
+				if(Double.isNaN(amountToAdd) || Double.isInfinite(amountToAdd) || (int)amountToAdd == 100) {
 					log.trace("Oops...amountToAdd is not a real number, it is " + amountToAdd + ", so it will NOT be in the moving average.");
+					continue;
 				}
+				movingAverage += amountToAdd;
+				divisor++;
 			}
 			if(divisor > 0) {
 				movingAverage /= divisor;
@@ -105,4 +106,88 @@ public class ChartListMakerUtilities {
 		return movingAverageList;
 	}
 
+	public static List<Map<Object, Object>> filterJumpsFromList(List<Map<Object, Object>> toFilter) {
+		// Method that takes out "large" jumps from day to day that are the result of bad data in the provided data sets
+		List<Map<Object, Object>> filteredList = new ArrayList<>(toFilter);
+		
+		if(filteredList.size() == 2) {
+			return filteredList;
+		}
+		
+		List<Double> yValues = new ArrayList<>();
+		for (Map<Object, Object> yValue : filteredList) {
+			yValues.add(Double.valueOf(yValue.get("y").toString()));
+		}
+		Collections.sort(yValues);
+		
+		int size = yValues.size();
+		boolean sizeIsEven = size % 2 == 0;
+//		double median = 0.0;
+		double Q1 = 0.0;
+		double Q3 = 0.0;
+		int iMedian = size / 2;
+		int iQ1 = 0;
+		int iQ3 = 0;
+		double IQR = 0.0;
+		double upper = 0.0;
+		double lower = 0.0;
+		if(sizeIsEven) {
+			//median = (yValues.get(iMedian - 1) + yValues.get(iMedian)) / 2.0;
+			iQ1 = (iMedian - 1) / 2;
+			iQ3 = 3 * iMedian / 2;
+			Q1 = yValues.get(iQ1);
+			Q3 = yValues.get(iQ3);
+		} else {
+			//median = yValues.get(iMedian);
+			iQ1 = iMedian / 2;
+			iQ3 = 3 * iMedian / 2;
+			Q1 = (yValues.get(iQ1) + yValues.get(iQ1 - 1)) / 2.0;
+			Q3 = (yValues.get(iQ3) + yValues.get( + 1)) / 2.0;
+		}
+		IQR = Q3 - Q1;
+		upper = Q3 + 1.5 * IQR;
+		lower = Q1 - 1.5 * IQR;
+		
+		log.info("Making the filtered list with lower = " + lower + " and upper = " + upper);
+		
+//		double absChangePct = 0.0;
+//		Object prevDayValue = 0.0;
+		Double todayValue = 0.0;
+//		Object prevOriginalValue = 0.0;
+		
+		for(int dayIndex = 1; dayIndex < filteredList.size(); dayIndex++) {
+			// Look for outliers
+			todayValue = yValues.get(dayIndex);
+//			todayValue = Double.valueOf(filteredList.get(dayIndex).get("y").toString());
+			if(todayValue < lower || todayValue > upper) {
+				log.info("Removing value: " + todayValue);
+				filteredList.remove(dayIndex);
+			}
+			
+			// Look for data points where the change from the previous day is greater than X%			
+//			todayValue = Double.valueOf(filteredList.get(dayIndex).get("y").toString());
+//			prevDayValue = Double.valueOf(filteredList.get(dayIndex - 1).get("y").toString());
+//			prevOriginalValue = filteredList.get(dayIndex - 1).get("y");
+//			absChangePct = Math.abs(((Double)todayValue / (Double)prevDayValue - 1) * 100.0);
+//			if(absChangePct > ChartListConstants.JUMP_FILTER_PERCENT_THRESHOLD_PCT.getValue()) {
+//				log.info("Removing value: " + todayValue);
+//				filteredList.get(dayIndex).put("y", prevOriginalValue);
+//				continue;
+//			}
+		}
+			
+		return filteredList;
+	}
+	
+	public static <T extends ICanonicalCaseDeathData> List<T> cleanDataList(List<T> regionData) {
+		// Method will clean out data where the daily change in a total quantity is negative.
+		List<T> toReturn = new ArrayList<T>(regionData);
+		
+//		int today = toReturn.get(0).getTotalPositiveCases();
+//		for(int i = 1; i < toReturn.size(); i++) {
+//			
+//		}
+		
+		return toReturn;
+	}	
 }

--- a/src/main/java/com/royware/corona/dashboard/services/chart/list/makers/CurrentTotalDeathsWithPercentOfPopulationChartList.java
+++ b/src/main/java/com/royware/corona/dashboard/services/chart/list/makers/CurrentTotalDeathsWithPercentOfPopulationChartList.java
@@ -11,7 +11,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
-import com.royware.corona.dashboard.enums.data.MovingAverageSizes;
+import com.royware.corona.dashboard.enums.data.ChartListConstants;
 import com.royware.corona.dashboard.interfaces.chartlist.IChartListMaker;
 import com.royware.corona.dashboard.interfaces.model.ICanonicalCaseDeathData;
 
@@ -47,7 +47,7 @@ public class CurrentTotalDeathsWithPercentOfPopulationChartList implements IChar
 			dailyChange = totalToday - totalYesterday;
 			dailyChange = dailyChange > 0 ? dailyChange : 0;
 
-			if(dayIndex < startDayIndex + MovingAverageSizes.CURRENT_DEATHS_QUEUE_SIZE_PRIMARY.getValue()) {
+			if(dayIndex < startDayIndex + ChartListConstants.CURRENT_DEATHS_QUEUE_SIZE_PRIMARY.getValue()) {
 				rollingSumPrimary = totalToday;
 			} else {
 				rollingSumPrimary += dailyChange - dailyChangeInDeathsPrimary.peek();
@@ -55,7 +55,7 @@ public class CurrentTotalDeathsWithPercentOfPopulationChartList implements IChar
 			}
 			dailyChangeInDeathsPrimary.add(dailyChange);
 			
-			if(dayIndex < startDayIndex + MovingAverageSizes.CURRENT_DEATHS_QUEUE_SIZE_SECONDARY.getValue()) {
+			if(dayIndex < startDayIndex + ChartListConstants.CURRENT_DEATHS_QUEUE_SIZE_SECONDARY.getValue()) {
 				rollingSumSecondary = totalToday;
 			} else {
 				rollingSumSecondary += dailyChange - dailyChangeInDeathsSecondary.peek();
@@ -65,13 +65,13 @@ public class CurrentTotalDeathsWithPercentOfPopulationChartList implements IChar
 			
 			xyPair = new HashMap<>();
 			xyPair.put("x", dayIndex);
-			xyPair.put("y", rollingSumPrimary * MovingAverageSizes.PER_CAPITA_BASIS.getValue() * 1.0 / regionPopulation);
+			xyPair.put("y", rollingSumPrimary * ChartListConstants.PER_CAPITA_BASIS.getValue() * 1.0 / regionPopulation);
 			xyPair.put("dateChecked", regionDataList.get(dayIndex).getDateChecked().toString());
 			dataListPrimary.add(xyPair);
 			
 			xyPairSec = new HashMap<>();
 			xyPairSec.put("x", dayIndex);
-			xyPairSec.put("y", rollingSumSecondary * MovingAverageSizes.PER_CAPITA_BASIS.getValue() * 1.0 / regionPopulation);
+			xyPairSec.put("y", rollingSumSecondary * ChartListConstants.PER_CAPITA_BASIS.getValue() * 1.0 / regionPopulation);
 			dataListSecondary.add(xyPairSec);
 			dayIndex++;
 		}

--- a/src/main/java/com/royware/corona/dashboard/services/chart/list/makers/CurrentTotalPositivesWithPercentOfPopulationChartList.java
+++ b/src/main/java/com/royware/corona/dashboard/services/chart/list/makers/CurrentTotalPositivesWithPercentOfPopulationChartList.java
@@ -11,7 +11,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
-import com.royware.corona.dashboard.enums.data.MovingAverageSizes;
+import com.royware.corona.dashboard.enums.data.ChartListConstants;
 import com.royware.corona.dashboard.interfaces.chartlist.IChartListMaker;
 import com.royware.corona.dashboard.interfaces.model.ICanonicalCaseDeathData;
 
@@ -46,7 +46,7 @@ public class CurrentTotalPositivesWithPercentOfPopulationChartList implements IC
 			dailyChange = totalToday - totalYesterday;
 			dailyChange = dailyChange > 0 ? dailyChange : 0;
 
-			if(dayIndex < MovingAverageSizes.CURRENT_POSITIVES_QUEUE_SIZE_PRIMARY.getValue()) {
+			if(dayIndex < ChartListConstants.CURRENT_POSITIVES_QUEUE_SIZE_PRIMARY.getValue()) {
 				rollingSumPrimary = totalToday;
 			} else {
 				rollingSumPrimary += dailyChange - dailyChangeInPositivesPrimary.peek();
@@ -54,7 +54,7 @@ public class CurrentTotalPositivesWithPercentOfPopulationChartList implements IC
 			}
 			dailyChangeInPositivesPrimary.add(dailyChange);
 			
-			if(dayIndex < MovingAverageSizes.CURRENT_POSITIVES_QUEUE_SIZE_SECONDARY.getValue()) {
+			if(dayIndex < ChartListConstants.CURRENT_POSITIVES_QUEUE_SIZE_SECONDARY.getValue()) {
 				rollingSumSecondary = totalToday;
 			} else {
 				rollingSumSecondary += dailyChange - dailyChangeInPositivesSecondary.peek();
@@ -64,13 +64,13 @@ public class CurrentTotalPositivesWithPercentOfPopulationChartList implements IC
 			
 			xyPair = new HashMap<>();
 			xyPair.put("x", dayIndex);
-			xyPair.put("y", rollingSumPrimary * MovingAverageSizes.PER_CAPITA_BASIS.getValue() * 1.0 / regionPopulation);
+			xyPair.put("y", rollingSumPrimary * ChartListConstants.PER_CAPITA_BASIS.getValue() * 1.0 / regionPopulation);
 			xyPair.put("dateChecked", regionDataList.get(dayIndex).getDateChecked().toString());
 			dataListPrimary.add(xyPair);
 			
 			xyPairSec = new HashMap<>();
 			xyPairSec.put("x", dayIndex);
-			xyPairSec.put("y", rollingSumSecondary * MovingAverageSizes.PER_CAPITA_BASIS.getValue() * 1.0 / regionPopulation);
+			xyPairSec.put("y", rollingSumSecondary * ChartListConstants.PER_CAPITA_BASIS.getValue() * 1.0 / regionPopulation);
 			dataListSecondary.add(xyPairSec);
 			dayIndex++;
 		}

--- a/src/main/java/com/royware/corona/dashboard/services/chart/list/makers/DailyAccelerationOfCasesWithMovingAverageChartList.java
+++ b/src/main/java/com/royware/corona/dashboard/services/chart/list/makers/DailyAccelerationOfCasesWithMovingAverageChartList.java
@@ -9,7 +9,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
-import com.royware.corona.dashboard.enums.data.MovingAverageSizes;
+import com.royware.corona.dashboard.enums.data.ChartListConstants;
 import com.royware.corona.dashboard.interfaces.chartlist.IChartListMaker;
 import com.royware.corona.dashboard.interfaces.model.ICanonicalCaseDeathData;
 
@@ -51,7 +51,7 @@ public class DailyAccelerationOfCasesWithMovingAverageChartList implements IChar
 		scatterChartDataLists.add(
 			ChartListMakerUtilities.makeMovingAverageList(
 					dailyAccelCases,
-					MovingAverageSizes.MOVING_AVERAGE_SIZE.getValue() + 1,
+					ChartListConstants.MOVING_AVERAGE_SIZE.getValue() + 1,
 					regionDataList.size()
 			));
 

--- a/src/main/java/com/royware/corona/dashboard/services/chart/list/makers/DailyAccelerationOfDeathsWithMovingAverageChartList.java
+++ b/src/main/java/com/royware/corona/dashboard/services/chart/list/makers/DailyAccelerationOfDeathsWithMovingAverageChartList.java
@@ -9,7 +9,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
-import com.royware.corona.dashboard.enums.data.MovingAverageSizes;
+import com.royware.corona.dashboard.enums.data.ChartListConstants;
 import com.royware.corona.dashboard.interfaces.chartlist.IChartListMaker;
 import com.royware.corona.dashboard.interfaces.model.ICanonicalCaseDeathData;
 
@@ -54,7 +54,7 @@ public class DailyAccelerationOfDeathsWithMovingAverageChartList implements ICha
 		scatterChartDataLists.add(
 				ChartListMakerUtilities.makeMovingAverageList(
 					dailyAccelDeaths,
-					startDayIndex + MovingAverageSizes.MOVING_AVERAGE_SIZE.getValue() + 1,
+					startDayIndex + ChartListConstants.MOVING_AVERAGE_SIZE.getValue() + 1,
 					regionDataList.size()
 				));
 

--- a/src/main/java/com/royware/corona/dashboard/services/chart/list/makers/DailyAndTotalCasesVersusTimeChartList.java
+++ b/src/main/java/com/royware/corona/dashboard/services/chart/list/makers/DailyAndTotalCasesVersusTimeChartList.java
@@ -9,7 +9,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
-import com.royware.corona.dashboard.enums.data.MovingAverageSizes;
+import com.royware.corona.dashboard.enums.data.ChartListConstants;
 import com.royware.corona.dashboard.interfaces.chartlist.IChartListMaker;
 import com.royware.corona.dashboard.interfaces.model.ICanonicalCaseDeathData;
 
@@ -58,7 +58,7 @@ public class DailyAndTotalCasesVersusTimeChartList implements IChartListMaker {
 		scatterChartDataLists.add(
 			ChartListMakerUtilities.makeMovingAverageList(
 					dailyNewCases,
-					MovingAverageSizes.MOVING_AVERAGE_SIZE.getValue(),
+					ChartListConstants.MOVING_AVERAGE_SIZE.getValue(),
 					regionDataList.size()
 			));
 		

--- a/src/main/java/com/royware/corona/dashboard/services/chart/list/makers/DailyHospitalizedNowWithMovingAverageChartList.java
+++ b/src/main/java/com/royware/corona/dashboard/services/chart/list/makers/DailyHospitalizedNowWithMovingAverageChartList.java
@@ -9,7 +9,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
-import com.royware.corona.dashboard.enums.data.MovingAverageSizes;
+import com.royware.corona.dashboard.enums.data.ChartListConstants;
 import com.royware.corona.dashboard.interfaces.chartlist.IChartListMaker;
 import com.royware.corona.dashboard.interfaces.model.ICanonicalCaseDeathData;
 
@@ -63,7 +63,7 @@ public class DailyHospitalizedNowWithMovingAverageChartList implements IChartLis
 		scatterChartDataLists.add(
 				ChartListMakerUtilities.makeMovingAverageList(
 					dailyHospitalizations,
-					startDayIndex + MovingAverageSizes.MOVING_AVERAGE_SIZE.getValue(),
+					startDayIndex + ChartListConstants.MOVING_AVERAGE_SIZE.getValue(),
 					regionDataList.size()
 				));
 		

--- a/src/main/java/com/royware/corona/dashboard/services/chart/list/makers/DailyHospitalizedTotalWithMovingAverageChartList.java
+++ b/src/main/java/com/royware/corona/dashboard/services/chart/list/makers/DailyHospitalizedTotalWithMovingAverageChartList.java
@@ -9,7 +9,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
-import com.royware.corona.dashboard.enums.data.MovingAverageSizes;
+import com.royware.corona.dashboard.enums.data.ChartListConstants;
 import com.royware.corona.dashboard.interfaces.chartlist.IChartListMaker;
 import com.royware.corona.dashboard.interfaces.model.ICanonicalCaseDeathData;
 
@@ -59,7 +59,7 @@ public class DailyHospitalizedTotalWithMovingAverageChartList implements IChartL
 		log.debug("Making moving average of DAILY NEW hospitalizations");
 		scatterChartDataLists.add(
 				ChartListMakerUtilities.makeMovingAverageList(
-					cumulHospitalizations, startDayIndex + MovingAverageSizes.MOVING_AVERAGE_SIZE.getValue(),
+					cumulHospitalizations, startDayIndex + ChartListConstants.MOVING_AVERAGE_SIZE.getValue(),
 					regionDataList.size()
 				));
 		

--- a/src/main/java/com/royware/corona/dashboard/services/chart/list/makers/DailyRateOfChangeOfCasesWithMovingAverageChartList.java
+++ b/src/main/java/com/royware/corona/dashboard/services/chart/list/makers/DailyRateOfChangeOfCasesWithMovingAverageChartList.java
@@ -9,7 +9,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
-import com.royware.corona.dashboard.enums.data.MovingAverageSizes;
+import com.royware.corona.dashboard.enums.data.ChartListConstants;
 import com.royware.corona.dashboard.interfaces.chartlist.IChartListMaker;
 import com.royware.corona.dashboard.interfaces.model.ICanonicalCaseDeathData;
 
@@ -50,7 +50,7 @@ public class DailyRateOfChangeOfCasesWithMovingAverageChartList implements IChar
 		scatterChartDataLists.add(
 			ChartListMakerUtilities.makeMovingAverageList(
 					dailyPctChgCases,
-					MovingAverageSizes.MOVING_AVERAGE_SIZE.getValue(),
+					ChartListConstants.MOVING_AVERAGE_SIZE.getValue(),
 					regionDataList.size()
 			));
 

--- a/src/main/java/com/royware/corona/dashboard/services/chart/list/makers/DailyRateOfChangeOfDeathsWithMovingAverageChartList.java
+++ b/src/main/java/com/royware/corona/dashboard/services/chart/list/makers/DailyRateOfChangeOfDeathsWithMovingAverageChartList.java
@@ -10,7 +10,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
-import com.royware.corona.dashboard.enums.data.MovingAverageSizes;
+import com.royware.corona.dashboard.enums.data.ChartListConstants;
 import com.royware.corona.dashboard.interfaces.chartlist.IChartListMaker;
 import com.royware.corona.dashboard.interfaces.model.ICanonicalCaseDeathData;
 
@@ -55,7 +55,7 @@ public class DailyRateOfChangeOfDeathsWithMovingAverageChartList implements ICha
 		scatterChartDataLists.add(
 				ChartListMakerUtilities.makeMovingAverageList(
 					dailyPctChgDeaths,
-					startDayIndex + MovingAverageSizes.MOVING_AVERAGE_SIZE.getValue(),
+					startDayIndex + ChartListConstants.MOVING_AVERAGE_SIZE.getValue(),
 					regionDataList.size()
 				));
 

--- a/src/main/java/com/royware/corona/dashboard/services/chart/list/makers/DailyRatioCasesToTestsWithMovingAverageChartList.java
+++ b/src/main/java/com/royware/corona/dashboard/services/chart/list/makers/DailyRatioCasesToTestsWithMovingAverageChartList.java
@@ -9,7 +9,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
-import com.royware.corona.dashboard.enums.data.MovingAverageSizes;
+import com.royware.corona.dashboard.enums.data.ChartListConstants;
 import com.royware.corona.dashboard.interfaces.chartlist.IChartListMaker;
 import com.royware.corona.dashboard.interfaces.model.ICanonicalCaseDeathData;
 
@@ -64,7 +64,7 @@ public class DailyRatioCasesToTestsWithMovingAverageChartList implements IChartL
 		scatterChartDataLists.add(
 				ChartListMakerUtilities.makeMovingAverageList(
 					dailyRatioOfTests,
-					MovingAverageSizes.MOVING_AVERAGE_SIZE.getValue(),
+					ChartListConstants.MOVING_AVERAGE_SIZE.getValue(),
 					regionDataList.size()
 				));
 

--- a/src/main/java/com/royware/corona/dashboard/services/chart/list/makers/DailyTestsTotalTestsVersusTimeChartList.java
+++ b/src/main/java/com/royware/corona/dashboard/services/chart/list/makers/DailyTestsTotalTestsVersusTimeChartList.java
@@ -9,7 +9,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
-import com.royware.corona.dashboard.enums.data.MovingAverageSizes;
+import com.royware.corona.dashboard.enums.data.ChartListConstants;
 import com.royware.corona.dashboard.interfaces.chartlist.IChartListMaker;
 import com.royware.corona.dashboard.interfaces.model.ICanonicalCaseDeathData;
 
@@ -57,7 +57,7 @@ public class DailyTestsTotalTestsVersusTimeChartList implements IChartListMaker 
 		scatterChartDataLists.add(
 			ChartListMakerUtilities.makeMovingAverageList(
 				dailyTests,
-				MovingAverageSizes.MOVING_AVERAGE_SIZE.getValue(),
+				ChartListConstants.MOVING_AVERAGE_SIZE.getValue(),
 				regionDataList.size()
 			));
 		

--- a/src/main/java/com/royware/corona/dashboard/services/chart/list/makers/DailyVaccTotalVaccVersusTimeChartList.java
+++ b/src/main/java/com/royware/corona/dashboard/services/chart/list/makers/DailyVaccTotalVaccVersusTimeChartList.java
@@ -9,7 +9,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
-import com.royware.corona.dashboard.enums.data.MovingAverageSizes;
+import com.royware.corona.dashboard.enums.data.ChartListConstants;
 import com.royware.corona.dashboard.interfaces.chartlist.IChartListMaker;
 import com.royware.corona.dashboard.interfaces.model.ICanonicalCaseDeathData;
 
@@ -57,7 +57,7 @@ public class DailyVaccTotalVaccVersusTimeChartList implements IChartListMaker {
 		scatterChartDataLists.add(
 				ChartListMakerUtilities.makeMovingAverageList(
 					dailyVacc,
-					MovingAverageSizes.MOVING_AVERAGE_SIZE.getValue(),
+					ChartListConstants.MOVING_AVERAGE_SIZE.getValue(),
 					regionDataList.size()
 				));
 		

--- a/src/main/java/com/royware/corona/dashboard/services/chart/list/makers/TotalDeathsVersusTimeWithExponentialFitChartList.java
+++ b/src/main/java/com/royware/corona/dashboard/services/chart/list/makers/TotalDeathsVersusTimeWithExponentialFitChartList.java
@@ -9,7 +9,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
-import com.royware.corona.dashboard.enums.data.MovingAverageSizes;
+import com.royware.corona.dashboard.enums.data.ChartListConstants;
 import com.royware.corona.dashboard.interfaces.chartlist.IChartListMaker;
 import com.royware.corona.dashboard.interfaces.model.ICanonicalCaseDeathData;
 
@@ -62,7 +62,7 @@ public class TotalDeathsVersusTimeWithExponentialFitChartList implements IChartL
 		scatterChartDataLists.add(
 			ChartListMakerUtilities.makeMovingAverageList(
 				dailyDeaths,
-				startDayIndex + MovingAverageSizes.MOVING_AVERAGE_SIZE.getValue(),
+				startDayIndex + ChartListConstants.MOVING_AVERAGE_SIZE.getValue(),
 				regionDataList.size()
 			));
 		

--- a/src/main/java/com/royware/corona/dashboard/services/dashboard/DashboardConfigServiceImpl.java
+++ b/src/main/java/com/royware/corona/dashboard/services/dashboard/DashboardConfigServiceImpl.java
@@ -10,7 +10,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.ui.ModelMap;
 
 import com.royware.corona.dashboard.enums.dashstats.DashStatsTypes;
-import com.royware.corona.dashboard.enums.data.MovingAverageSizes;
+import com.royware.corona.dashboard.enums.data.ChartListConstants;
 import com.royware.corona.dashboard.enums.regions.RegionsInDashboard;
 import com.royware.corona.dashboard.interfaces.dashboard.IDashboardChartService;
 import com.royware.corona.dashboard.interfaces.dashboard.IDashboardConfigService;
@@ -111,7 +111,7 @@ public class DashboardConfigServiceImpl implements IDashboardConfigService {
 				DashStatsTypes.DASHSTATS_PER_CAPITA_STATS, dashStats, null, null, regionPopulation);
 		
 		//////// SET ALL DASHBOARD META DATA AND HEADER DATA ////////
-		dashMeta.setPerCapitaBasis(MovingAverageSizes.PER_CAPITA_BASIS.getValue());
+		dashMeta.setPerCapitaBasis(ChartListConstants.PER_CAPITA_BASIS.getValue());
 		dashHeader.setFullRegion(fullRegionString);
 		if(fullRegionString.length() > MAX_REGION_LENGTH_TO_DISPLAY) {
 			dashHeader.setFullRegion(fullRegionString.substring(0, MAX_REGION_LENGTH_TO_DISPLAY + 1) + "...");

--- a/src/main/java/com/royware/corona/dashboard/services/dashboard/DashboardConfigServiceImpl.java
+++ b/src/main/java/com/royware/corona/dashboard/services/dashboard/DashboardConfigServiceImpl.java
@@ -6,6 +6,7 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Component;
 import org.springframework.ui.ModelMap;
 
@@ -37,6 +38,7 @@ public class DashboardConfigServiceImpl implements IDashboardConfigService {
 	@Autowired private IMultiRegionExternalDataService dashboardMultiRegionService;
 	@Autowired private IRegionDemographicDataGetterStore regionDemoDataStore;
 	@Autowired private IExternalDataGetterStore externalDataGetterStore;
+	@Autowired private Environment appConfig;
 	
 	private static final Logger log = LoggerFactory.getLogger(DashboardConfigServiceImpl.class);
 	
@@ -58,20 +60,19 @@ public class DashboardConfigServiceImpl implements IDashboardConfigService {
 		//////// GET ALL DATA FROM EXTERNAL SOURCE(S) ////////
 		//Need to get the data differently for a multi-region selection 
 		//As of 03/07/2021, there is no longer a single source of data available for the U.S., so need to treat it like a multi-region
+		boolean toValueOfAppConfigCleanData = Boolean.parseBoolean(appConfig.getProperty("corona.filter.data"));
 		if(isMultiRegion) {
 			fullRegionString = rawRegionString;
 			String regionsOnlyCsvString = dashboardMultiRegionService.getStatesFromMultiRegionString(rawRegionString);
 			regionPopulation = dashboardMultiRegionService.getMultiRegionPopulation(regionsOnlyCsvString);
+			dataService.setCleanNegativeChangesFromTotals(toValueOfAppConfigCleanData);
 			dataList = dashboardMultiRegionService.getMultiRegionDataFromExternalSource(regionsOnlyCsvString, dataService);
 		} else {
 			RegionsInDashboard region = RegionsInDashboard.valueOfEnum(rawRegionString);
 			fullRegionString = regionDemoDataStore.getRegionFullNameFor(region);
 			regionPopulation = regionDemoDataStore.getRegionPopulationFor(region);
+			dataService.setCleanNegativeChangesFromTotals(toValueOfAppConfigCleanData);
 			dataList = externalDataGetterStore.getDataFor(region, dataService);
-			
-//			fullRegionString = RegionsData.valueOf(rawRegionString).getRegionData().getFullName();
-//			regionPopulation = RegionsData.valueOf(rawRegionString).getRegionData().getPopulation();
-//			dataList = RegionsData.valueOf(rawRegionString).getCoronaVirusDataFromExternalSource(dataService);
 		}
 		log.debug("fullRegionString: " + fullRegionString + ", regionPopulation: " + regionPopulation + ", dataList size: " + dataList.size());
 		log.info("Finished making the data list...");
@@ -94,16 +95,12 @@ public class DashboardConfigServiceImpl implements IDashboardConfigService {
 			dashMeta.setRegionType("world");
 		} else if((rawRegionString.length() == 2 || isMultiRegion) && populateUSTotals) {
 			dashMeta.setRegionType("state");
-			//dashboardChartService.makeDashboardRowByUsTotals(regionPopulation, dashStats);
 			log.info("Making all the DASHBOARD STATISTICS FOR REGION - BY U.S. TOTALS");
 			log.debug("Getting U.S. data for populating By U.S. Totals row of dashboard...");
 			
 			List<UnitedStatesData> usaData = externalDataGetterStore.getDataFor(RegionsInDashboard.USA,
 					getExternalDataServiceFromFactory(RegionsInDashboard.USA.name()));
 
-//			List<UnitedStatesData> usaData = RegionsData.USA
-//				.getCoronaVirusDataFromExternalSource(getExternalDataServiceFromFactory(RegionsData.USA.name()));
-			
 			dashStats = dashStatsStore.produceDashboardStatsForType(DashStatsTypes.DASHSTATS_BY_US_TOTALS, dashStats, usaData, null, regionPopulation);
 		}
 		

--- a/src/main/java/com/royware/corona/dashboard/services/dashstats/makers/DashStatsForRegionDeathsMovingSumMaker.java
+++ b/src/main/java/com/royware/corona/dashboard/services/dashstats/makers/DashStatsForRegionDeathsMovingSumMaker.java
@@ -3,7 +3,7 @@ package com.royware.corona.dashboard.services.dashstats.makers;
 import java.util.List;
 import java.util.Map;
 
-import com.royware.corona.dashboard.enums.data.MovingAverageSizes;
+import com.royware.corona.dashboard.enums.data.ChartListConstants;
 import com.royware.corona.dashboard.interfaces.dashboard.IDashStatsMaker;
 import com.royware.corona.dashboard.interfaces.model.ICanonicalCaseDeathData;
 import com.royware.corona.dashboard.model.dashboard.DashboardStatistics;
@@ -21,12 +21,12 @@ public class DashStatsForRegionDeathsMovingSumMaker implements IDashStatsMaker {
 		
 		List<Map<Object, Object>> chartDataList = (List<Map<Object, Object>>) chartData.get(0);
 		dashStats.setDeathsMovingSumPrimary(
-				(double) ChartConfigMakerUtilities.computeTotalQuantityLastN(chartDataList, MovingAverageSizes.CURRENT_POSITIVES_QUEUE_SIZE_PRIMARY.getValue())
-				* 1.0 * MovingAverageSizes.PER_CAPITA_BASIS.getValue()
+				(double) ChartConfigMakerUtilities.computeTotalQuantityLastN(chartDataList, ChartListConstants.CURRENT_POSITIVES_QUEUE_SIZE_PRIMARY.getValue())
+				* 1.0 * ChartListConstants.PER_CAPITA_BASIS.getValue()
 				/ regionPop);
 		dashStats.setDeathsMovingSumSecondary(
-				(double) ChartConfigMakerUtilities.computeTotalQuantityLastN(chartDataList, MovingAverageSizes.CURRENT_POSITIVES_QUEUE_SIZE_SECONDARY.getValue())
-				* 1.0 * MovingAverageSizes.PER_CAPITA_BASIS.getValue()
+				(double) ChartConfigMakerUtilities.computeTotalQuantityLastN(chartDataList, ChartListConstants.CURRENT_POSITIVES_QUEUE_SIZE_SECONDARY.getValue())
+				* 1.0 * ChartListConstants.PER_CAPITA_BASIS.getValue()
 				/ regionPop);
 		
 		return dashStats;

--- a/src/main/java/com/royware/corona/dashboard/services/dashstats/makers/DashStatsForRegionVaccMaker.java
+++ b/src/main/java/com/royware/corona/dashboard/services/dashstats/makers/DashStatsForRegionVaccMaker.java
@@ -3,7 +3,7 @@ package com.royware.corona.dashboard.services.dashstats.makers;
 import java.util.List;
 import java.util.Map;
 
-import com.royware.corona.dashboard.enums.data.MovingAverageSizes;
+import com.royware.corona.dashboard.enums.data.ChartListConstants;
 import com.royware.corona.dashboard.interfaces.dashboard.IDashStatsMaker;
 import com.royware.corona.dashboard.interfaces.model.ICanonicalCaseDeathData;
 import com.royware.corona.dashboard.model.dashboard.DashboardStatistics;
@@ -24,12 +24,12 @@ public class DashStatsForRegionVaccMaker implements IDashStatsMaker {
 		dashStats.setVaccToday((int) chartData.get(0).get(chartData.get(0).size() - 1).get("y")
 				- (int) chartData.get(0).get(chartData.get(0).size() - 2).get("y"));
 		dashStats.setVaccMovingSumPrimary(
-				(double) ChartConfigMakerUtilities.computeTotalQuantityLastN(chartDataList, MovingAverageSizes.CURRENT_POSITIVES_QUEUE_SIZE_PRIMARY.getValue())
-				* 1.0 * MovingAverageSizes.PER_CAPITA_BASIS.getValue()
+				(double) ChartConfigMakerUtilities.computeTotalQuantityLastN(chartDataList, ChartListConstants.CURRENT_POSITIVES_QUEUE_SIZE_PRIMARY.getValue())
+				* 1.0 * ChartListConstants.PER_CAPITA_BASIS.getValue()
 				/ regionPop);
 		dashStats.setVaccMovingSumSecondary(
-				(double) ChartConfigMakerUtilities.computeTotalQuantityLastN(chartDataList, MovingAverageSizes.CURRENT_POSITIVES_QUEUE_SIZE_SECONDARY.getValue())
-				* 1.0 * MovingAverageSizes.PER_CAPITA_BASIS.getValue()
+				(double) ChartConfigMakerUtilities.computeTotalQuantityLastN(chartDataList, ChartListConstants.CURRENT_POSITIVES_QUEUE_SIZE_SECONDARY.getValue())
+				* 1.0 * ChartListConstants.PER_CAPITA_BASIS.getValue()
 				/ regionPop);
 		
 		return dashStats;

--- a/src/main/java/com/royware/corona/dashboard/services/dashstats/makers/DashStatsForUSRegionsByTestingMaker.java
+++ b/src/main/java/com/royware/corona/dashboard/services/dashstats/makers/DashStatsForUSRegionsByTestingMaker.java
@@ -6,7 +6,7 @@ import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.royware.corona.dashboard.enums.data.MovingAverageSizes;
+import com.royware.corona.dashboard.enums.data.ChartListConstants;
 import com.royware.corona.dashboard.enums.regions.RegionsInDashboard;
 import com.royware.corona.dashboard.interfaces.dashboard.IDashStatsMaker;
 import com.royware.corona.dashboard.interfaces.model.ICanonicalCaseDeathData;
@@ -32,10 +32,10 @@ public class DashStatsForUSRegionsByTestingMaker implements IDashStatsMaker {
 		log.debug("Making ProportionOfPositiveTests and ProportionOfPositiveTestsMovingAverage");
 		dashStats.setProportionOfPositiveTests(dataList.get(dataList.size() - 1).getTotalPositiveCases()
 				* 100.0 / dashStats.getTotalTestsConducted());
-		int totalTestsLastN = ChartConfigMakerUtilities.computeTotalQuantityLastN(chartData.get(0), MovingAverageSizes.CURRENT_POSITIVES_QUEUE_SIZE_PRIMARY.getValue());
+		int totalTestsLastN = ChartConfigMakerUtilities.computeTotalQuantityLastN(chartData.get(0), ChartListConstants.CURRENT_POSITIVES_QUEUE_SIZE_PRIMARY.getValue());
 		dashStats.setTotalTestsConductedLastN(totalTestsLastN);
 		dashStats.setProportionOfPositiveTestsMovingAverage(
-				ChartConfigMakerUtilities.computeTotalQuantityLastN(chartData.get(0), MovingAverageSizes.CURRENT_POSITIVES_QUEUE_SIZE_PRIMARY.getValue())* 100.0 / totalTestsLastN);
+				ChartConfigMakerUtilities.computeTotalQuantityLastN(chartData.get(0), ChartListConstants.CURRENT_POSITIVES_QUEUE_SIZE_PRIMARY.getValue())* 100.0 / totalTestsLastN);
 		log.debug("Making ProportionOfPopulationTested");
 		dashStats.setProportionOfPopulationTested(dashStats.getTotalTestsConducted()
 				* 100.0 / usaPop);

--- a/src/main/java/com/royware/corona/dashboard/services/dashstats/makers/DashStatsPerCapitaStatsMaker.java
+++ b/src/main/java/com/royware/corona/dashboard/services/dashstats/makers/DashStatsPerCapitaStatsMaker.java
@@ -3,7 +3,7 @@ package com.royware.corona.dashboard.services.dashstats.makers;
 import java.util.List;
 import java.util.Map;
 
-import com.royware.corona.dashboard.enums.data.MovingAverageSizes;
+import com.royware.corona.dashboard.enums.data.ChartListConstants;
 import com.royware.corona.dashboard.interfaces.dashboard.IDashStatsMaker;
 import com.royware.corona.dashboard.interfaces.model.ICanonicalCaseDeathData;
 import com.royware.corona.dashboard.model.dashboard.DashboardStatistics;
@@ -18,11 +18,11 @@ public class DashStatsPerCapitaStatsMaker implements IDashStatsMaker {
 			dashStats = new DashboardStatistics();
 		}
 		
-		dashStats.setCasesPerCapita(dashStats.getCasesTotal() * 1.0 * MovingAverageSizes.PER_CAPITA_BASIS.getValue() / regionPop);
+		dashStats.setCasesPerCapita(dashStats.getCasesTotal() * 1.0 * ChartListConstants.PER_CAPITA_BASIS.getValue() / regionPop);
 		dashStats.setCasesPercentOfPop(dashStats.getCasesTotal() * 100.0 / regionPop);
-		dashStats.setDeathsPerCapita(dashStats.getDeathsTotal() * 1.0 * MovingAverageSizes.PER_CAPITA_BASIS.getValue() / regionPop);
+		dashStats.setDeathsPerCapita(dashStats.getDeathsTotal() * 1.0 * ChartListConstants.PER_CAPITA_BASIS.getValue() / regionPop);
 		dashStats.setDeathsPercentOfPop(dashStats.getDeathsTotal() * 100.0 / regionPop);
-		dashStats.setVaccPerCapita(dashStats.getTotalVaccCompleted() * 1.0 * MovingAverageSizes.PER_CAPITA_BASIS.getValue() / regionPop);
+		dashStats.setVaccPerCapita(dashStats.getTotalVaccCompleted() * 1.0 * ChartListConstants.PER_CAPITA_BASIS.getValue() / regionPop);
 		dashStats.setVaccPercentOfPop(dashStats.getTotalVaccCompleted() * 100.0 / regionPop);
 		
 		return dashStats;

--- a/src/main/java/com/royware/corona/dashboard/services/data/cache/CacheActionsUnitedStatesImpl.java
+++ b/src/main/java/com/royware/corona/dashboard/services/data/cache/CacheActionsUnitedStatesImpl.java
@@ -22,6 +22,13 @@ public class CacheActionsUnitedStatesImpl implements ICacheActions {
 	private static final Logger log = LoggerFactory.getLogger(ExternalDataServiceWorldImpl.class);
 	private static final String CACHE_KEY = CacheKeys.CACHE_KEY_US.getName();
 	
+	private boolean cleanData;
+	
+	@Override
+	public void setCleanData(boolean cleanData) {
+		this.cleanData = cleanData;
+	}
+
 	@Autowired
 	@Qualifier(value = "us")
 	private IExternalDataConnectionService usaDataService;
@@ -69,6 +76,7 @@ public class CacheActionsUnitedStatesImpl implements ICacheActions {
 	}
 	
 	private List<UnitedStatesData> getNewCacheDataFromSource() {
+		usaDataService.setCleanNegativeChangesFromTotals(cleanData);
 		return usaDataService.makeDataListFromExternalSource(CACHE_KEY);
 	}
 

--- a/src/main/java/com/royware/corona/dashboard/services/data/cache/CacheActionsWorldImpl.java
+++ b/src/main/java/com/royware/corona/dashboard/services/data/cache/CacheActionsWorldImpl.java
@@ -24,6 +24,13 @@ public class CacheActionsWorldImpl implements ICacheActions {
 	@Autowired
 	private IWorldDataServiceCaller worldDataServiceCaller;
 	
+	private boolean cleanData;
+	
+	@Override
+	public void setCleanData(boolean cleanData) {
+		this.cleanData = cleanData;
+	}
+
 	@Override
 	@Scheduled(initialDelayString = "${spring.cache.refresh.period.world}", fixedDelayString = "${spring.cache.refresh.period.world}")
 	public void cacheEvictAndRepopulate() {
@@ -50,7 +57,6 @@ public class CacheActionsWorldImpl implements ICacheActions {
 		log.debug("In the evictCache method: " + LocalDateTime.now());
 		log.debug("EVICTING...");
 		CacheManagerProvider.getManager().put(CACHE_KEY, null);
-		//CacheManagerProvider.getManager().clear();
 		log.debug("...DONE");
 	}	
 

--- a/src/main/java/com/royware/corona/dashboard/services/data/us/ExternalDataServiceMultiStateImpl.java
+++ b/src/main/java/com/royware/corona/dashboard/services/data/us/ExternalDataServiceMultiStateImpl.java
@@ -22,11 +22,21 @@ public class ExternalDataServiceMultiStateImpl implements IExternalDataConnectio
 	@Qualifier(value = "singleState")
 	private IExternalDataConnectionService singleStateDataService;
 	
+	private boolean toCleanNegativeChangesFromTotals = false;
+	
+	@Override
+	public void setCleanNegativeChangesFromTotals(boolean cleanNegativeChangesFromTotals) {
+		this.toCleanNegativeChangesFromTotals = cleanNegativeChangesFromTotals;
+	}
+
 	@SuppressWarnings("unchecked")
 	@Override
 	public List<UnitedStatesData> makeDataListFromExternalSource(String multiRegionState) {
 		log.debug("MULTI_REGION: ABOUT TO HIT ENDPOINT FOR STATE DATA FOR: " + multiRegionState);
+		
+		singleStateDataService.setCleanNegativeChangesFromTotals(toCleanNegativeChangesFromTotals);
 		List<UnitedStatesData> stateDataList = singleStateDataService.makeDataListFromExternalSource(multiRegionState);
+		
 		log.debug("FINISHED GETTING DATA FOR STATE: " + multiRegionState);
 		
 		return stateDataList;

--- a/src/main/java/com/royware/corona/dashboard/services/data/us/ExternalDataServiceSingleStateImpl.java
+++ b/src/main/java/com/royware/corona/dashboard/services/data/us/ExternalDataServiceSingleStateImpl.java
@@ -127,26 +127,94 @@ public class ExternalDataServiceSingleStateImpl implements IExternalDataConnecti
 		List<Integer> allCaseDates = Arrays.asList(datesArray);
 		
 		//Transform the data from the maps into the desired object		
+		UnitedStatesData usd = makeUSDataObject(stateAbbrev, hospitalizations, caseDeathVacc, allCaseDates.get(0));
+		int totalCasesYesterday = usd.getTotalPositiveCases();
+		int totalDeathsYesterday = usd.getTotalDeaths();
+		int totalVaccYesterday = usd.getTotalVaccCompleted();
+		
+		int anchorCases = 0;
+		int anchorDeaths = 0;
+		int anchorVacc = 0;
+		boolean compareToAnchorCases = false;
+		boolean compareToAnchorDeaths = false;
+		boolean compareToAnchorVacc = false;
+		
+		boolean cleanNegativeChangesFromTotals = true;
+		
 		for(Integer caseDate : allCaseDates) {
 			if(caseDeathVacc.get(caseDate).getTotalCases() < 100) {
 				continue;
 			}
-			UnitedStatesData usd = new UnitedStatesData();
-			usd.setDateChecked(caseDeathVacc.get(caseDate).getDatesCDC().getDateAsLocalDate());
-			usd.setDateInteger(caseDate);
-			usd.setDateTimeString(caseDeathVacc.get(caseDate).getDatesCDC().getDateAsStringYYYYMMDD());
-			usd.setRegionString(stateAbbrev);
-			usd.setTotalPositiveCases(caseDeathVacc.get(caseDate).getTotalCases());
-			usd.setTotalDeaths(caseDeathVacc.get(caseDate).getTotalDeaths());
-			if(caseDeathVacc.get(caseDate).getVaccComp() >= 100) {
-				usd.setTotalVaccCompleted(caseDeathVacc.get(caseDate).getVaccComp());
-			}
-			if(hospitalizations.containsKey(caseDate)) {
-				usd.setHospitalizedCurrently(hospitalizations.get(caseDate).getTotalBedsCovidCurrently());
-			}
+			usd = makeUSDataObject(stateAbbrev, hospitalizations, caseDeathVacc, caseDate);
+			
+			// CLEAN NEGATIVE CHANGES IN TOTALS FOR CASES, DEATHS, VACC, AND HOSP
+			// This works by setting the anchor value to the last good value, then continuing
+			// through the loop until the daily change in total value becomes positive.
+			if(cleanNegativeChangesFromTotals) {
+				int totalCasesToday = usd.getTotalPositiveCases();
+				int totalDeathsToday = usd.getTotalDeaths();
+				int totalVaccToday = usd.getTotalVaccCompleted();
+				int changeInCases = totalCasesToday - (compareToAnchorCases ? anchorCases : totalCasesYesterday);
+				int changeInDeaths = totalDeathsToday - (compareToAnchorDeaths ? anchorDeaths : totalDeathsYesterday);
+				int changeInVacc = totalVaccToday - (compareToAnchorVacc ? anchorVacc : totalVaccYesterday);
+				
+				// Only add to the list if all three changes are positive
+				if(changeInCases < 0) {
+					anchorCases = compareToAnchorCases ? anchorCases : totalCasesYesterday;
+					compareToAnchorCases = true;
+					continue;
+				}
+				else {
+					compareToAnchorCases = false;
+					totalCasesYesterday = totalCasesToday;
+				}
+				
+				if(changeInDeaths < 0) {
+					anchorDeaths = compareToAnchorDeaths ? anchorDeaths : totalDeathsYesterday;
+					compareToAnchorDeaths = true;
+					continue;
+				}
+				else {
+					compareToAnchorDeaths = false;
+					totalDeathsYesterday = totalDeathsToday;
+				}
+				
+				if(changeInVacc < 0) {
+					anchorVacc = compareToAnchorVacc ? anchorVacc : totalVaccYesterday;
+					compareToAnchorVacc = true;
+					continue;
+				}
+				else {
+					compareToAnchorVacc = false;
+					totalVaccYesterday = totalVaccToday;
+				}
+			}			
+			
+			
 			toReturn.add(usd);
 		}
 		
 		return toReturn;
+	}
+
+	private UnitedStatesData makeUSDataObject(
+			String stateAbbrev,
+			Map<Integer, HospitalDataCDC> hospitalizations,
+			Map<Integer, CaseDeathVaccData_CovidActNow> caseDeathVacc,
+			Integer caseDate) {
+		UnitedStatesData usd = new UnitedStatesData();
+		usd.setDateChecked(caseDeathVacc.get(caseDate).getDatesCDC().getDateAsLocalDate());
+		usd.setDateInteger(caseDate);
+		usd.setDateTimeString(caseDeathVacc.get(caseDate).getDatesCDC().getDateAsStringYYYYMMDD());
+		usd.setRegionString(stateAbbrev);
+		usd.setTotalPositiveCases(caseDeathVacc.get(caseDate).getTotalCases());
+		usd.setTotalDeaths(caseDeathVacc.get(caseDate).getTotalDeaths());
+		if(caseDeathVacc.get(caseDate).getVaccComp() >= 100) {
+			usd.setTotalVaccCompleted(caseDeathVacc.get(caseDate).getVaccComp());
+		}
+		if(hospitalizations.containsKey(caseDate)) {
+			usd.setHospitalizedCurrently(hospitalizations.get(caseDate).getTotalBedsCovidCurrently());
+		}
+		return usd;
 	}
 }

--- a/src/main/java/com/royware/corona/dashboard/services/data/us/ExternalDataServiceSingleStateImpl.java
+++ b/src/main/java/com/royware/corona/dashboard/services/data/us/ExternalDataServiceSingleStateImpl.java
@@ -30,6 +30,13 @@ public class ExternalDataServiceSingleStateImpl implements IExternalDataConnecti
 	
 	private static final Logger log = LoggerFactory.getLogger(ExternalDataServiceSingleStateImpl.class);
 	
+	private boolean toCleanNegativeChangesFromTotals;
+	
+	@Override
+	public void setCleanNegativeChangesFromTotals(boolean cleanNegativeChangesFromTotals) {
+		this.toCleanNegativeChangesFromTotals = cleanNegativeChangesFromTotals;
+	}
+
 	@SuppressWarnings("unchecked")
 	@Override
 	public List<UnitedStatesData> makeDataListFromExternalSource(String stateAbbreviation) {
@@ -138,9 +145,7 @@ public class ExternalDataServiceSingleStateImpl implements IExternalDataConnecti
 		boolean compareToAnchorCases = false;
 		boolean compareToAnchorDeaths = false;
 		boolean compareToAnchorVacc = false;
-		
-		boolean cleanNegativeChangesFromTotals = true;
-		
+				
 		for(Integer caseDate : allCaseDates) {
 			if(caseDeathVacc.get(caseDate).getTotalCases() < 100) {
 				continue;
@@ -150,7 +155,7 @@ public class ExternalDataServiceSingleStateImpl implements IExternalDataConnecti
 			// CLEAN NEGATIVE CHANGES IN TOTALS FOR CASES, DEATHS, VACC, AND HOSP
 			// This works by setting the anchor value to the last good value, then continuing
 			// through the loop until the daily change in total value becomes positive.
-			if(cleanNegativeChangesFromTotals) {
+			if(toCleanNegativeChangesFromTotals) {
 				int totalCasesToday = usd.getTotalPositiveCases();
 				int totalDeathsToday = usd.getTotalDeaths();
 				int totalVaccToday = usd.getTotalVaccCompleted();
@@ -217,4 +222,6 @@ public class ExternalDataServiceSingleStateImpl implements IExternalDataConnecti
 		}
 		return usd;
 	}
+
+	
 }

--- a/src/main/java/com/royware/corona/dashboard/services/data/us/ExternalDataServiceUSAExcludingStateImpl.java
+++ b/src/main/java/com/royware/corona/dashboard/services/data/us/ExternalDataServiceUSAExcludingStateImpl.java
@@ -26,12 +26,20 @@ public class ExternalDataServiceUSAExcludingStateImpl implements IExternalDataCo
 	private IExternalDataConnectionService stateDataService;
 	
 	private static final Logger log = LoggerFactory.getLogger(ExternalDataServiceUSAExcludingStateImpl.class);
-	
+		
+	private boolean toCleanNegativeChangesFromTotals;
+	@Override
+	public void setCleanNegativeChangesFromTotals(boolean cleanNegativeChangesFromTotals) {
+		this.toCleanNegativeChangesFromTotals = cleanNegativeChangesFromTotals;
+	}
+
 	@SuppressWarnings("unchecked")
 	@Override
 	public List<UnitedStatesData> makeDataListFromExternalSource(String stateToExclude) {
 		//call getAllUsData, then call the states API and subtract out the state numbers
 		log.info("***** ABOUT TO <<<FILTER OUT>>> STATE: " + stateToExclude + " ****");
+		usDataService.setCleanNegativeChangesFromTotals(toCleanNegativeChangesFromTotals);
+		stateDataService.setCleanNegativeChangesFromTotals(toCleanNegativeChangesFromTotals);
 		List<UnitedStatesData> usDataExcludingState = usDataService.makeDataListFromExternalSource(CacheKeys.CACHE_KEY_US.getName());
 		List<UnitedStatesData> stateDataToExclude = stateDataService.makeDataListFromExternalSource(stateToExclude);
 		

--- a/src/main/java/com/royware/corona/dashboard/services/data/us/ExternalDataServiceUSAImpl.java
+++ b/src/main/java/com/royware/corona/dashboard/services/data/us/ExternalDataServiceUSAImpl.java
@@ -28,6 +28,13 @@ public class ExternalDataServiceUSAImpl implements IExternalDataConnectionServic
 	@Autowired
 	private IExternalDataServiceFactory dataService;
 
+	private boolean toCleanNegativeChangesFromTotals;
+	
+	@Override
+	public void setCleanNegativeChangesFromTotals(boolean cleanNegativeChangesFromTotals) {
+		this.toCleanNegativeChangesFromTotals = cleanNegativeChangesFromTotals;
+	}
+
 	//Pull data directly from the cache always
 	@SuppressWarnings("unchecked")
 	@Override
@@ -36,6 +43,7 @@ public class ExternalDataServiceUSAImpl implements IExternalDataConnectionServic
 		List<UnitedStatesData> usaData = safeGetDataFromCache(cacheKey);
 		if(usaData == null || usaData.isEmpty()) {
 			log.info("US Data not in cache. Getting the USA data from its source (via multi-region).");
+			multiRegionDataService.setCleanNegativeChangesFromTotals(toCleanNegativeChangesFromTotals);
 			usaData = multiRegionDataService.getMultiRegionDataFromExternalSource(
 					IDashboardConfigService.ALL_STATES_AS_CSV,
 					dataService.getExternalDataService("MULTI")

--- a/src/main/java/com/royware/corona/dashboard/services/data/us/MultiRegionExternalDataServiceImpl.java
+++ b/src/main/java/com/royware/corona/dashboard/services/data/us/MultiRegionExternalDataServiceImpl.java
@@ -28,6 +28,13 @@ public class MultiRegionExternalDataServiceImpl implements IMultiRegionExternalD
 	@Autowired
 	private IMultiRegionListStitcher listStitcher;
 	
+	private boolean toCleanNegativeChangesFromTotals = false;
+	
+	@Override
+	public void setCleanNegativeChangesFromTotals(boolean cleanNegativeChangesFromTotals) {
+		this.toCleanNegativeChangesFromTotals = cleanNegativeChangesFromTotals;
+	}
+	
 	@Override
 	public String getStatesFromMultiRegionString(String region) {
 		String regionsOnly = region.substring(region.indexOf(':') + 1);
@@ -89,6 +96,9 @@ public class MultiRegionExternalDataServiceImpl implements IMultiRegionExternalD
 		
 		log.info("Getting the multi-region data from an external source");
 		String[] states = makeUniqueArrayOfStates(fullRegionName);
+		
+		// Set the switch to filter negative changes from the final stitched list
+		listStitcher.setCleanNegativeChangesFromTotals(toCleanNegativeChangesFromTotals);
 		
 		mapOfStateDataLists = listStitcher.makeMapOfStateDataLists(dataService, states);
 		

--- a/src/main/java/com/royware/corona/dashboard/services/data/us/MultiRegionExternalDataServiceImpl.java
+++ b/src/main/java/com/royware/corona/dashboard/services/data/us/MultiRegionExternalDataServiceImpl.java
@@ -27,7 +27,7 @@ public class MultiRegionExternalDataServiceImpl implements IMultiRegionExternalD
 	
 	@Autowired
 	private IMultiRegionListStitcher listStitcher;
-
+	
 	@Override
 	public String getStatesFromMultiRegionString(String region) {
 		String regionsOnly = region.substring(region.indexOf(':') + 1);
@@ -93,7 +93,7 @@ public class MultiRegionExternalDataServiceImpl implements IMultiRegionExternalD
 		mapOfStateDataLists = listStitcher.makeMapOfStateDataLists(dataService, states);
 		
 		multiRegionDataList = listStitcher.stitchMultiStateListsIntoOneList(mapOfStateDataLists, states);
-		
+				
 		log.info("Finished getting the multi-region data from an external source");
 		return multiRegionDataList;
 	}

--- a/src/main/java/com/royware/corona/dashboard/services/data/us/MultiRegionListStitcherImpl.java
+++ b/src/main/java/com/royware/corona/dashboard/services/data/us/MultiRegionListStitcherImpl.java
@@ -9,8 +9,6 @@ import java.util.TreeMap;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Component;
 
 import com.royware.corona.dashboard.enums.data.DataFields;
@@ -21,14 +19,14 @@ import com.royware.corona.dashboard.model.data.us.UnitedStatesData;
 @Component
 public class MultiRegionListStitcherImpl implements IMultiRegionListStitcher {
 	private static final Logger log = LoggerFactory.getLogger(MultiRegionListStitcherImpl.class);
-	
-//	@Autowired
-//	private Environment appConfig;
-	
-	//private boolean cleanNegativeChangesFromTotals = Boolean.parseBoolean(appConfig.getProperty("corona.filter.data"));
-	private boolean cleanNegativeChangesFromTotals = true;
+		
+	private boolean toCleanNegativeChangesFromTotals;
 	
 	@Override
+	public void setCleanNegativeChangesFromTotals(boolean cleanNegativeChangesFromTotals) {
+		this.toCleanNegativeChangesFromTotals = cleanNegativeChangesFromTotals;
+	}
+
 	public List<UnitedStatesData> stitchMultiStateListsIntoOneList(Map<String, List<UnitedStatesData>> mapOfStateDataLists, String[] states) {
 		Map<Integer, Integer> sumPositiveCases = new TreeMap<>();
 		Map<Integer, Integer> sumNegativeCases = new TreeMap<>();
@@ -126,7 +124,7 @@ public class MultiRegionListStitcherImpl implements IMultiRegionListStitcher {
 			
 			// This works by setting the anchor value to the last good value, then continuing
 			// through the loop until the daily change in total value becomes positive.
-			if(cleanNegativeChangesFromTotals) {
+			if(toCleanNegativeChangesFromTotals) {
 				int totalCasesToday = thisDateForRegion.getTotalPositiveCases();
 				int totalDeathsToday = thisDateForRegion.getTotalDeaths();
 				int totalVaccToday = thisDateForRegion.getTotalVaccCompleted();
@@ -168,7 +166,7 @@ public class MultiRegionListStitcherImpl implements IMultiRegionListStitcher {
 			
 			multiRegionDataListToReturn.add(thisDateForRegion);
 		}
-		log.debug("Finished making the " + (cleanNegativeChangesFromTotals ? "CLEANED" : "ORIGINAL") + " region data list and ready to return it.");
+		log.debug("Finished making the " + (toCleanNegativeChangesFromTotals ? "CLEANED" : "ORIGINAL") + " region data list and ready to return it.");
 		
 		return multiRegionDataListToReturn;
 	}
@@ -205,6 +203,10 @@ public class MultiRegionListStitcherImpl implements IMultiRegionListStitcher {
 		//Make a map where the key is the state and the value is the list of data for the state
 		log.debug("The array of states for getting data is:");
 		int i = 1;
+		
+		// Don't clean the individual state data; only filter the stitched list
+		dataService.setCleanNegativeChangesFromTotals(false);
+		
 		for(String state : states) {
 			log.info("(" + i + ") " + state);
 			i++;

--- a/src/main/java/com/royware/corona/dashboard/services/data/us/MultiRegionListStitcherImpl.java
+++ b/src/main/java/com/royware/corona/dashboard/services/data/us/MultiRegionListStitcherImpl.java
@@ -9,6 +9,8 @@ import java.util.TreeMap;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Component;
 
 import com.royware.corona.dashboard.enums.data.DataFields;
@@ -18,11 +20,16 @@ import com.royware.corona.dashboard.model.data.us.UnitedStatesData;
 
 @Component
 public class MultiRegionListStitcherImpl implements IMultiRegionListStitcher {
-	private static final Logger log = LoggerFactory.getLogger(MultiRegionExternalDataServiceImpl.class);
+	private static final Logger log = LoggerFactory.getLogger(MultiRegionListStitcherImpl.class);
+	
+//	@Autowired
+//	private Environment appConfig;
+	
+	//private boolean cleanNegativeChangesFromTotals = Boolean.parseBoolean(appConfig.getProperty("corona.filter.data"));
+	private boolean cleanNegativeChangesFromTotals = true;
 	
 	@Override
 	public List<UnitedStatesData> stitchMultiStateListsIntoOneList(Map<String, List<UnitedStatesData>> mapOfStateDataLists, String[] states) {
-		List<UnitedStatesData> multiRegionDataListToReturn = new ArrayList<>();
 		Map<Integer, Integer> sumPositiveCases = new TreeMap<>();
 		Map<Integer, Integer> sumNegativeCases = new TreeMap<>();
 		Map<Integer, Integer> sumPosNegCases = new TreeMap<>();
@@ -71,33 +78,124 @@ public class MultiRegionListStitcherImpl implements IMultiRegionListStitcher {
 		}
 		log.debug("Made all the DATA FIELD maps containing the SUMS for all states in the multi-region");
 		
-		//NOW, iterate through the keys from the latest case date through the current day as an integer
+		return mapDataSourceListsToUnitedStatesData(sumPositiveCases, sumNegativeCases,
+				sumPosNegCases, sumVaccinations, sumDeaths);
+	}
+
+	private List<UnitedStatesData> mapDataSourceListsToUnitedStatesData(
+			Map<Integer, Integer> sumPositiveCases,
+			Map<Integer, Integer> sumNegativeCases,
+			Map<Integer, Integer> sumPosNegCases,
+			Map<Integer, Integer> sumVaccinations,
+			Map<Integer, Integer> sumDeaths) {
+		
+		//Iterate through the keys from the latest case date through the current day as an integer
 		//and construct a list of UnitedStatesData objects that will contain the sum for the whole region for each day
 		//Get all available date strings and create a list of UnitedStatesData objects from the various maps
-		for(Integer dateInteger : sumPositiveCases.keySet()) {
-			multiRegionDataListToReturn.add(new UnitedStatesData());
-			UnitedStatesData thisDateForRegion = multiRegionDataListToReturn.get(multiRegionDataListToReturn.size() - 1);
-			LocalDate localDate = localDateFromStringDate(dateInteger + "");
-			thisDateForRegion.setDateTimeString(localDate.toString());
-			thisDateForRegion.setDateChecked(localDate);
-			thisDateForRegion.setDateInteger(dateInteger);
-			thisDateForRegion.setTotalPositiveCases(sumPositiveCases.get(dateInteger));
-			thisDateForRegion.setTotalNegativeCases(sumNegativeCases.get(dateInteger));
-			thisDateForRegion.setTotalPositivePlusNegative(sumPosNegCases.get(dateInteger));
-			if(sumDeaths.containsKey(dateInteger)) {
-				thisDateForRegion.setTotalVaccCompleted(sumVaccinations.get(dateInteger));
-			} else {
-				thisDateForRegion.setTotalVaccCompleted(0);
-			}
-			if(sumDeaths.containsKey(dateInteger)) {
-				thisDateForRegion.setTotalDeaths(sumDeaths.get(dateInteger));
-			} else {
-				thisDateForRegion.setTotalDeaths(0);
-			}
+		List<UnitedStatesData> multiRegionDataListToReturn = new ArrayList<>();
+		
+		Integer[] caseDates = sumPositiveCases.keySet().toArray(new Integer[sumPositiveCases.size()]);
+		
+		UnitedStatesData thisDateForRegion = makeUSDataObject(
+				sumPositiveCases,
+				sumNegativeCases,
+				sumPosNegCases,
+				sumVaccinations,
+				sumDeaths,
+				caseDates[0]);
+		
+		int totalCasesYesterday = thisDateForRegion.getTotalPositiveCases();
+		int totalDeathsYesterday = thisDateForRegion.getTotalDeaths();
+		int totalVaccYesterday = thisDateForRegion.getTotalVaccCompleted();
+		
+		int anchorCases = 0;
+		int anchorDeaths = 0;
+		int anchorVacc = 0;
+		boolean compareToAnchorCases = false;
+		boolean compareToAnchorDeaths = false;
+		boolean compareToAnchorVacc = false;
+		
+		for(int i = 1; i < caseDates.length; i++) {
+			thisDateForRegion = makeUSDataObject(
+					sumPositiveCases,
+					sumNegativeCases,
+					sumPosNegCases,
+					sumVaccinations,
+					sumDeaths,
+					caseDates[i]);
+			
+			// This works by setting the anchor value to the last good value, then continuing
+			// through the loop until the daily change in total value becomes positive.
+			if(cleanNegativeChangesFromTotals) {
+				int totalCasesToday = thisDateForRegion.getTotalPositiveCases();
+				int totalDeathsToday = thisDateForRegion.getTotalDeaths();
+				int totalVaccToday = thisDateForRegion.getTotalVaccCompleted();
+				int changeInCases = totalCasesToday - (compareToAnchorCases ? anchorCases : totalCasesYesterday);
+				int changeInDeaths = totalDeathsToday - (compareToAnchorDeaths ? anchorDeaths : totalDeathsYesterday);
+				int changeInVacc = totalVaccToday - (compareToAnchorVacc ? anchorVacc : totalVaccYesterday);
+				
+				// Only add to the list if all three changes are positive
+				if(changeInCases < 0) {
+					anchorCases = compareToAnchorCases ? anchorCases : totalCasesYesterday;
+					compareToAnchorCases = true;
+					continue;
+				}
+				else {
+					compareToAnchorCases = false;
+					totalCasesYesterday = totalCasesToday;
+				}
+				
+				if(changeInDeaths < 0) {
+					anchorDeaths = compareToAnchorDeaths ? anchorDeaths : totalDeathsYesterday;
+					compareToAnchorDeaths = true;
+					continue;
+				}
+				else {
+					compareToAnchorDeaths = false;
+					totalDeathsYesterday = totalDeathsToday;
+				}
+				
+				if(changeInVacc < 0) {
+					anchorVacc = compareToAnchorVacc ? anchorVacc : totalVaccYesterday;
+					compareToAnchorVacc = true;
+					continue;
+				}
+				else {
+					compareToAnchorVacc = false;
+					totalVaccYesterday = totalVaccToday;
+				}
+			}			
+			
+			multiRegionDataListToReturn.add(thisDateForRegion);
 		}
-		log.debug("Finished making the region data list and ready to return it.");
+		log.debug("Finished making the " + (cleanNegativeChangesFromTotals ? "CLEANED" : "ORIGINAL") + " region data list and ready to return it.");
 		
 		return multiRegionDataListToReturn;
+	}
+
+	private UnitedStatesData makeUSDataObject(Map<Integer, Integer> sumPositiveCases,
+			Map<Integer, Integer> sumNegativeCases, Map<Integer, Integer> sumPosNegCases,
+			Map<Integer, Integer> sumVaccinations, Map<Integer, Integer> sumDeaths, Integer dateInteger) {
+		
+		UnitedStatesData thisDateForRegion = new UnitedStatesData();
+		LocalDate localDate = localDateFromStringDate(dateInteger + "");
+		thisDateForRegion.setDateTimeString(localDate.toString());
+		thisDateForRegion.setDateChecked(localDate);
+		thisDateForRegion.setDateInteger(dateInteger);
+		thisDateForRegion.setTotalPositiveCases(sumPositiveCases.get(dateInteger));
+		thisDateForRegion.setTotalNegativeCases(sumNegativeCases.get(dateInteger));
+		thisDateForRegion.setTotalPositivePlusNegative(sumPosNegCases.get(dateInteger));
+		if(sumVaccinations.containsKey(dateInteger)) {
+			thisDateForRegion.setTotalVaccCompleted(sumVaccinations.get(dateInteger));
+		} else {
+			thisDateForRegion.setTotalVaccCompleted(0);
+		}
+		if(sumDeaths.containsKey(dateInteger)) {
+			thisDateForRegion.setTotalDeaths(sumDeaths.get(dateInteger));
+		} else {
+			thisDateForRegion.setTotalDeaths(0);
+		}
+		return thisDateForRegion;
 	}
 
 	@Override

--- a/src/main/java/com/royware/corona/dashboard/services/data/world/ExternalDataServiceSingleCountryImpl.java
+++ b/src/main/java/com/royware/corona/dashboard/services/data/world/ExternalDataServiceSingleCountryImpl.java
@@ -30,6 +30,13 @@ public class ExternalDataServiceSingleCountryImpl implements IExternalDataConnec
 	private static final int MINIMUM_TOTAL_CASES_FOR_INCLUSION = 100;
 	private static final Logger log = LoggerFactory.getLogger(ExternalDataServiceSingleCountryImpl.class);
 	
+	private boolean toCleanNegativeChangesFromTotals;
+	
+	@Override
+	public void setCleanNegativeChangesFromTotals(boolean cleanNegativeChangesFromTotals) {
+		this.toCleanNegativeChangesFromTotals = cleanNegativeChangesFromTotals;
+	}
+
 	@SuppressWarnings("unchecked")
 	@Override
 	public List<WorldData> makeDataListFromExternalSource(String countryThreeLetterCode) {

--- a/src/main/java/com/royware/corona/dashboard/services/data/world/ExternalDataServiceWorldImpl.java
+++ b/src/main/java/com/royware/corona/dashboard/services/data/world/ExternalDataServiceWorldImpl.java
@@ -43,6 +43,13 @@ public class ExternalDataServiceWorldImpl implements IExternalDataConnectionServ
 	private ConcurrentMapCache cacheManager;
 	private static final Logger log = LoggerFactory.getLogger(ExternalDataServiceWorldImpl.class);
 
+	private boolean toCleanNegativeChangesFromTotals = false;
+	
+	@Override
+	public void setCleanNegativeChangesFromTotals(boolean cleanNegativeChangesFromTotals) {
+		this.toCleanNegativeChangesFromTotals = cleanNegativeChangesFromTotals;
+	}
+
 	//Pull data directly from the cache always
 	@SuppressWarnings("unchecked")
 	@Override

--- a/src/main/resources/application-LOCAL.properties
+++ b/src/main/resources/application-LOCAL.properties
@@ -4,3 +4,4 @@ spring.world.data.source = "OWID"
 spring.usa.data.source = "CDC"
 spring.external.connect.timeout = 5000
 spring.external.read.timeout = 30000
+corona.filter.data = true

--- a/src/main/resources/application-PROD.properties
+++ b/src/main/resources/application-PROD.properties
@@ -4,3 +4,4 @@ spring.world.data.source = "OWID"
 spring.usa.data.source = "CDC"
 spring.external.connect.timeout = 10000
 spring.external.read.timeout = 45000
+corona.filter.data = true


### PR DESCRIPTION
Implemented a cleaner algorithm that eliminates "glitches" in the data set where total data (e.g. cases, deaths) have a negative daily change. The cleaner can be turned on or off from the application config file. Currently, the cleaner is only for US data (states, regions, and all US), but not the world data.