### PR TITLE
Fixed HTTP 500 errors when selecting a country

### DIFF
--- a/src/main/java/com/royware/corona/dashboard/enums/data/DataTransformConstants.java
+++ b/src/main/java/com/royware/corona/dashboard/enums/data/DataTransformConstants.java
@@ -1,17 +1,19 @@
 package com.royware.corona.dashboard.enums.data;
 
-public enum ChartListConstants {
+public enum DataTransformConstants {
 	MOVING_AVERAGE_SIZE(4),
 	CURRENT_POSITIVES_QUEUE_SIZE_PRIMARY(7),
 	CURRENT_POSITIVES_QUEUE_SIZE_SECONDARY(10),
 	CURRENT_DEATHS_QUEUE_SIZE_PRIMARY(7),
 	CURRENT_DEATHS_QUEUE_SIZE_SECONDARY(10),
 	PER_CAPITA_BASIS(100000),
-	JUMP_FILTER_PERCENT_THRESHOLD_PCT(50);
+	JUMP_FILTER_PERCENT_THRESHOLD_PCT(50),
+	MINIMUM_NUMBER_OF_DAILY_CASES_FOR_INCLUSION(100),
+	US_CUTOFF_DATE(20200304);
 	
 	public final Integer size;
 	
-	private ChartListConstants(Integer size) {
+	private DataTransformConstants(Integer size) {
 		this.size = size;
 	}
 	

--- a/src/main/java/com/royware/corona/dashboard/interfaces/data/IExternalDataListGetter.java
+++ b/src/main/java/com/royware/corona/dashboard/interfaces/data/IExternalDataListGetter.java
@@ -5,8 +5,6 @@ import java.util.List;
 import com.royware.corona.dashboard.interfaces.model.ICanonicalCaseDeathData;
 
 public interface IExternalDataListGetter {
-	public static final int US_CUTOFF_DATE = 20200304;
-	
 	public <T extends ICanonicalCaseDeathData> List<T> makeDataListFromExternalSource(String cacheKey);
 	public void setCleanNegativeChangesFromTotals(boolean cleanNegativeChangesFromTotals);
 }

--- a/src/main/java/com/royware/corona/dashboard/services/chart/config/makers/ChartConfigAccelerationOfCases.java
+++ b/src/main/java/com/royware/corona/dashboard/services/chart/config/makers/ChartConfigAccelerationOfCases.java
@@ -3,7 +3,7 @@ package com.royware.corona.dashboard.services.chart.config.makers;
 import java.util.List;
 import java.util.Map;
 
-import com.royware.corona.dashboard.enums.data.ChartListConstants;
+import com.royware.corona.dashboard.enums.data.DataTransformConstants;
 import com.royware.corona.dashboard.interfaces.chartconfig.IChartConfigMaker;
 import com.royware.corona.dashboard.model.dashboard.DashboardChartConfig;
 
@@ -20,7 +20,7 @@ public class ChartConfigAccelerationOfCases implements IChartConfigMaker {
 		chartConfig.setxAxisTitle("Days Since Cases > 0");
 		chartConfig.setyAxisTitle("Percent Change in Rate of New Positives");
 		chartConfig.setDataSeries1Name("Acceleration of Positives");
-		chartConfig.setDataSeries2Name(ChartListConstants.MOVING_AVERAGE_SIZE.getValue() + "-day Moving Average");
+		chartConfig.setDataSeries2Name(DataTransformConstants.MOVING_AVERAGE_SIZE.getValue() + "-day Moving Average");
 
 		chartConfig.setChartType("scatter");
 		chartConfig.setyAxisNumberSuffix("%");

--- a/src/main/java/com/royware/corona/dashboard/services/chart/config/makers/ChartConfigAccelerationOfDeaths.java
+++ b/src/main/java/com/royware/corona/dashboard/services/chart/config/makers/ChartConfigAccelerationOfDeaths.java
@@ -3,7 +3,7 @@ package com.royware.corona.dashboard.services.chart.config.makers;
 import java.util.List;
 import java.util.Map;
 
-import com.royware.corona.dashboard.enums.data.ChartListConstants;
+import com.royware.corona.dashboard.enums.data.DataTransformConstants;
 import com.royware.corona.dashboard.interfaces.chartconfig.IChartConfigMaker;
 import com.royware.corona.dashboard.model.dashboard.DashboardChartConfig;
 
@@ -23,7 +23,7 @@ public class ChartConfigAccelerationOfDeaths implements IChartConfigMaker {
 		chartConfig.setxAxisTitle("Days Since Deaths > 0");
 		chartConfig.setyAxisTitle("Percent Change in Rate of New Deaths");
 		chartConfig.setDataSeries1Name("Acceleration of Deaths");
-		chartConfig.setDataSeries2Name(ChartListConstants.MOVING_AVERAGE_SIZE.getValue() + "-day Moving Average");
+		chartConfig.setDataSeries2Name(DataTransformConstants.MOVING_AVERAGE_SIZE.getValue() + "-day Moving Average");
 		
 		chartConfig.setyAxisNumberSuffix("%");
 		chartConfig.setxAxisPosition("bottom");

--- a/src/main/java/com/royware/corona/dashboard/services/chart/config/makers/ChartConfigCasesByTime.java
+++ b/src/main/java/com/royware/corona/dashboard/services/chart/config/makers/ChartConfigCasesByTime.java
@@ -3,7 +3,7 @@ package com.royware.corona.dashboard.services.chart.config.makers;
 import java.util.List;
 import java.util.Map;
 
-import com.royware.corona.dashboard.enums.data.ChartListConstants;
+import com.royware.corona.dashboard.enums.data.DataTransformConstants;
 import com.royware.corona.dashboard.interfaces.chartconfig.IChartConfigMaker;
 import com.royware.corona.dashboard.model.dashboard.DashboardChartConfig;
 
@@ -17,7 +17,7 @@ public class ChartConfigCasesByTime implements IChartConfigMaker {
 		chartConfig.setxAxisTitle("Days Since Cases > 0");
 		chartConfig.setyAxisTitle("Total Positive Tests");
 		chartConfig.setDataSeries1Name("Total Positives");
-		chartConfig.setDataSeries2Name(ChartListConstants.MOVING_AVERAGE_SIZE.getValue() + "-day Moving Average of New Positives");
+		chartConfig.setDataSeries2Name(DataTransformConstants.MOVING_AVERAGE_SIZE.getValue() + "-day Moving Average of New Positives");
 
 		chartConfig.setChartType("scatter");
 		chartConfig.setyAxisNumberSuffix("");

--- a/src/main/java/com/royware/corona/dashboard/services/chart/config/makers/ChartConfigCumulativeHospitalizationsByTime.java
+++ b/src/main/java/com/royware/corona/dashboard/services/chart/config/makers/ChartConfigCumulativeHospitalizationsByTime.java
@@ -3,7 +3,7 @@ package com.royware.corona.dashboard.services.chart.config.makers;
 import java.util.List;
 import java.util.Map;
 
-import com.royware.corona.dashboard.enums.data.ChartListConstants;
+import com.royware.corona.dashboard.enums.data.DataTransformConstants;
 import com.royware.corona.dashboard.interfaces.chartconfig.IChartConfigMaker;
 import com.royware.corona.dashboard.model.dashboard.DashboardChartConfig;
 
@@ -22,7 +22,7 @@ public class ChartConfigCumulativeHospitalizationsByTime implements IChartConfig
 		chartConfig.setxAxisTitle("Days Since Cases > 0");
 		chartConfig.setyAxisTitle("Cumulative Hospitalizations");
 		chartConfig.setDataSeries1Name("Cumulative Hospitalizations");
-		chartConfig.setDataSeries2Name(ChartListConstants.MOVING_AVERAGE_SIZE.getValue() + "-day Moving Average of New Hospitalizations");
+		chartConfig.setDataSeries2Name(DataTransformConstants.MOVING_AVERAGE_SIZE.getValue() + "-day Moving Average of New Hospitalizations");
 		
 		chartConfig.setyAxisNumberSuffix("");
 		chartConfig.setxAxisPosition("bottom");

--- a/src/main/java/com/royware/corona/dashboard/services/chart/config/makers/ChartConfigCurrentHospitalizationsByTime.java
+++ b/src/main/java/com/royware/corona/dashboard/services/chart/config/makers/ChartConfigCurrentHospitalizationsByTime.java
@@ -3,7 +3,7 @@ package com.royware.corona.dashboard.services.chart.config.makers;
 import java.util.List;
 import java.util.Map;
 
-import com.royware.corona.dashboard.enums.data.ChartListConstants;
+import com.royware.corona.dashboard.enums.data.DataTransformConstants;
 import com.royware.corona.dashboard.interfaces.chartconfig.IChartConfigMaker;
 import com.royware.corona.dashboard.model.dashboard.DashboardChartConfig;
 
@@ -22,7 +22,7 @@ public class ChartConfigCurrentHospitalizationsByTime implements IChartConfigMak
 		chartConfig.setxAxisTitle("Days Since Cases > 0");
 		chartConfig.setyAxisTitle("Current Hospitalizations");
 		chartConfig.setDataSeries1Name("Current Hospitalizations");
-		chartConfig.setDataSeries2Name(ChartListConstants.MOVING_AVERAGE_SIZE.getValue() + "-day Moving Average of New Hospitalizations");
+		chartConfig.setDataSeries2Name(DataTransformConstants.MOVING_AVERAGE_SIZE.getValue() + "-day Moving Average of New Hospitalizations");
 		
 		chartConfig.setyAxisNumberSuffix("");
 		chartConfig.setxAxisPosition("bottom");

--- a/src/main/java/com/royware/corona/dashboard/services/chart/config/makers/ChartConfigDeathsByTime.java
+++ b/src/main/java/com/royware/corona/dashboard/services/chart/config/makers/ChartConfigDeathsByTime.java
@@ -3,7 +3,7 @@ package com.royware.corona.dashboard.services.chart.config.makers;
 import java.util.List;
 import java.util.Map;
 
-import com.royware.corona.dashboard.enums.data.ChartListConstants;
+import com.royware.corona.dashboard.enums.data.DataTransformConstants;
 import com.royware.corona.dashboard.interfaces.chartconfig.IChartConfigMaker;
 import com.royware.corona.dashboard.model.dashboard.DashboardChartConfig;
 
@@ -22,7 +22,7 @@ public class ChartConfigDeathsByTime implements IChartConfigMaker {
 		chartConfig.setxAxisTitle("Days Since Deaths > 0");
 		chartConfig.setyAxisTitle("Total Deaths");
 		chartConfig.setDataSeries1Name("Total Deaths");
-		chartConfig.setDataSeries2Name(ChartListConstants.MOVING_AVERAGE_SIZE.getValue() + "-day Moving Average of New Deaths");
+		chartConfig.setDataSeries2Name(DataTransformConstants.MOVING_AVERAGE_SIZE.getValue() + "-day Moving Average of New Deaths");
 		
 		chartConfig.setyAxisNumberSuffix("");
 		chartConfig.setxAxisPosition("bottom");

--- a/src/main/java/com/royware/corona/dashboard/services/chart/config/makers/ChartConfigRateOfChangeOfCases.java
+++ b/src/main/java/com/royware/corona/dashboard/services/chart/config/makers/ChartConfigRateOfChangeOfCases.java
@@ -3,7 +3,7 @@ package com.royware.corona.dashboard.services.chart.config.makers;
 import java.util.List;
 import java.util.Map;
 
-import com.royware.corona.dashboard.enums.data.ChartListConstants;
+import com.royware.corona.dashboard.enums.data.DataTransformConstants;
 import com.royware.corona.dashboard.interfaces.chartconfig.IChartConfigMaker;
 import com.royware.corona.dashboard.model.dashboard.DashboardChartConfig;
 
@@ -20,7 +20,7 @@ public class ChartConfigRateOfChangeOfCases implements IChartConfigMaker {
 		chartConfig.setxAxisTitle("Days Since Cases > 0");
 		chartConfig.setyAxisTitle("Percent Change in New Positives");
 		chartConfig.setDataSeries1Name("% Change in Positives");
-		chartConfig.setDataSeries2Name(ChartListConstants.MOVING_AVERAGE_SIZE.getValue() + "-day Moving Average");
+		chartConfig.setDataSeries2Name(DataTransformConstants.MOVING_AVERAGE_SIZE.getValue() + "-day Moving Average");
 
 		chartConfig.setChartType("scatter");
 		chartConfig.setyAxisNumberSuffix("%");

--- a/src/main/java/com/royware/corona/dashboard/services/chart/config/makers/ChartConfigRateOfChangeOfDeaths.java
+++ b/src/main/java/com/royware/corona/dashboard/services/chart/config/makers/ChartConfigRateOfChangeOfDeaths.java
@@ -3,7 +3,7 @@ package com.royware.corona.dashboard.services.chart.config.makers;
 import java.util.List;
 import java.util.Map;
 
-import com.royware.corona.dashboard.enums.data.ChartListConstants;
+import com.royware.corona.dashboard.enums.data.DataTransformConstants;
 import com.royware.corona.dashboard.interfaces.chartconfig.IChartConfigMaker;
 import com.royware.corona.dashboard.model.dashboard.DashboardChartConfig;
 
@@ -22,7 +22,7 @@ public class ChartConfigRateOfChangeOfDeaths implements IChartConfigMaker {
 		chartConfig.setxAxisTitle("Days Since Deaths > 0");
 		chartConfig.setyAxisTitle("Percent Change in New Deaths");
 		chartConfig.setDataSeries1Name("% change in deaths");
-		chartConfig.setDataSeries2Name(ChartListConstants.MOVING_AVERAGE_SIZE.getValue() + "-day Moving Average");
+		chartConfig.setDataSeries2Name(DataTransformConstants.MOVING_AVERAGE_SIZE.getValue() + "-day Moving Average");
 		
 		chartConfig.setyAxisNumberSuffix("%");
 		chartConfig.setxAxisPosition("bottom");

--- a/src/main/java/com/royware/corona/dashboard/services/chart/config/makers/ChartConfigRatioOfCasesToTestsByTime.java
+++ b/src/main/java/com/royware/corona/dashboard/services/chart/config/makers/ChartConfigRatioOfCasesToTestsByTime.java
@@ -3,7 +3,7 @@ package com.royware.corona.dashboard.services.chart.config.makers;
 import java.util.List;
 import java.util.Map;
 
-import com.royware.corona.dashboard.enums.data.ChartListConstants;
+import com.royware.corona.dashboard.enums.data.DataTransformConstants;
 import com.royware.corona.dashboard.interfaces.chartconfig.IChartConfigMaker;
 import com.royware.corona.dashboard.model.dashboard.DashboardChartConfig;
 
@@ -22,7 +22,7 @@ public class ChartConfigRatioOfCasesToTestsByTime implements IChartConfigMaker {
 		chartConfig.setxAxisTitle("Days Since Cases > 0");
 		chartConfig.setyAxisTitle("Ratio of Positives to Tests, %");
 		chartConfig.setDataSeries1Name("% Positive per Test");
-		chartConfig.setDataSeries2Name(ChartListConstants.MOVING_AVERAGE_SIZE.getValue() + "-day Moving Average");
+		chartConfig.setDataSeries2Name(DataTransformConstants.MOVING_AVERAGE_SIZE.getValue() + "-day Moving Average");
 		
 		chartConfig.setyAxisNumberSuffix("%");
 		chartConfig.setxAxisPosition("bottom");

--- a/src/main/java/com/royware/corona/dashboard/services/chart/config/makers/ChartConfigTestsByTime.java
+++ b/src/main/java/com/royware/corona/dashboard/services/chart/config/makers/ChartConfigTestsByTime.java
@@ -3,7 +3,7 @@ package com.royware.corona.dashboard.services.chart.config.makers;
 import java.util.List;
 import java.util.Map;
 
-import com.royware.corona.dashboard.enums.data.ChartListConstants;
+import com.royware.corona.dashboard.enums.data.DataTransformConstants;
 import com.royware.corona.dashboard.interfaces.chartconfig.IChartConfigMaker;
 import com.royware.corona.dashboard.model.dashboard.DashboardChartConfig;
 
@@ -22,7 +22,7 @@ public class ChartConfigTestsByTime implements IChartConfigMaker {
 		chartConfig.setxAxisTitle("Days Since Cases > 0");
 		chartConfig.setyAxisTitle("Total Tests");
 		chartConfig.setDataSeries1Name("Total Tests");
-		chartConfig.setDataSeries2Name(ChartListConstants.MOVING_AVERAGE_SIZE.getValue() + "-day Moving Average of New Tests");
+		chartConfig.setDataSeries2Name(DataTransformConstants.MOVING_AVERAGE_SIZE.getValue() + "-day Moving Average of New Tests");
 		
 		chartConfig.setyAxisNumberSuffix("");
 		chartConfig.setxAxisPosition("bottom");

--- a/src/main/java/com/royware/corona/dashboard/services/chart/config/makers/ChartConfigTotalCurrentCases.java
+++ b/src/main/java/com/royware/corona/dashboard/services/chart/config/makers/ChartConfigTotalCurrentCases.java
@@ -4,7 +4,7 @@ import java.text.NumberFormat;
 import java.util.List;
 import java.util.Map;
 
-import com.royware.corona.dashboard.enums.data.ChartListConstants;
+import com.royware.corona.dashboard.enums.data.DataTransformConstants;
 import com.royware.corona.dashboard.interfaces.chartconfig.IChartConfigMaker;
 import com.royware.corona.dashboard.model.dashboard.DashboardChartConfig;
 
@@ -18,11 +18,11 @@ public class ChartConfigTotalCurrentCases implements IChartConfigMaker {
 
 		chartConfig.setChartTitle("Time History of Positivity Rate in " + region);
 		chartConfig.setxAxisTitle("Days Since Cases > 0");
-		chartConfig.setyAxisTitle("Positives per " + NumberFormat.getNumberInstance().format(ChartListConstants.PER_CAPITA_BASIS.getValue()));
-		chartConfig.setDataSeries1Name("Positives per " + NumberFormat.getNumberInstance().format(ChartListConstants.PER_CAPITA_BASIS.getValue())
-				+ " (Last " + ChartListConstants.CURRENT_POSITIVES_QUEUE_SIZE_PRIMARY.getValue() + " days)");
-		chartConfig.setDataSeries2Name("Positives per " + NumberFormat.getNumberInstance().format(ChartListConstants.PER_CAPITA_BASIS.getValue())
-				+ " (Last " + ChartListConstants.CURRENT_POSITIVES_QUEUE_SIZE_SECONDARY.getValue() + " days)");
+		chartConfig.setyAxisTitle("Positives per " + NumberFormat.getNumberInstance().format(DataTransformConstants.PER_CAPITA_BASIS.getValue()));
+		chartConfig.setDataSeries1Name("Positives per " + NumberFormat.getNumberInstance().format(DataTransformConstants.PER_CAPITA_BASIS.getValue())
+				+ " (Last " + DataTransformConstants.CURRENT_POSITIVES_QUEUE_SIZE_PRIMARY.getValue() + " days)");
+		chartConfig.setDataSeries2Name("Positives per " + NumberFormat.getNumberInstance().format(DataTransformConstants.PER_CAPITA_BASIS.getValue())
+				+ " (Last " + DataTransformConstants.CURRENT_POSITIVES_QUEUE_SIZE_SECONDARY.getValue() + " days)");
 
 		chartConfig.setyAxisNumberSuffix("");
 		chartConfig.setxAxisPosition("bottom");

--- a/src/main/java/com/royware/corona/dashboard/services/chart/config/makers/ChartConfigVaccByTime.java
+++ b/src/main/java/com/royware/corona/dashboard/services/chart/config/makers/ChartConfigVaccByTime.java
@@ -3,7 +3,7 @@ package com.royware.corona.dashboard.services.chart.config.makers;
 import java.util.List;
 import java.util.Map;
 
-import com.royware.corona.dashboard.enums.data.ChartListConstants;
+import com.royware.corona.dashboard.enums.data.DataTransformConstants;
 import com.royware.corona.dashboard.interfaces.chartconfig.IChartConfigMaker;
 import com.royware.corona.dashboard.model.dashboard.DashboardChartConfig;
 
@@ -22,7 +22,7 @@ public class ChartConfigVaccByTime implements IChartConfigMaker {
 		chartConfig.setxAxisTitle("Days Since Cases > 0");
 		chartConfig.setyAxisTitle("Total Vaccinations");
 		chartConfig.setDataSeries1Name("Total Vaccinations Completed");
-		chartConfig.setDataSeries2Name(ChartListConstants.MOVING_AVERAGE_SIZE.getValue() + "-day Moving Average of New Vacc");
+		chartConfig.setDataSeries2Name(DataTransformConstants.MOVING_AVERAGE_SIZE.getValue() + "-day Moving Average of New Vacc");
 		
 		chartConfig.setyAxisNumberSuffix("");
 		chartConfig.setxAxisPosition("bottom");

--- a/src/main/java/com/royware/corona/dashboard/services/chart/list/makers/ChartListMakerUtilities.java
+++ b/src/main/java/com/royware/corona/dashboard/services/chart/list/makers/ChartListMakerUtilities.java
@@ -8,7 +8,7 @@ import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.royware.corona.dashboard.enums.data.ChartListConstants;
+import com.royware.corona.dashboard.enums.data.DataTransformConstants;
 import com.royware.corona.dashboard.interfaces.model.ICanonicalCaseDeathData;
 
 public class ChartListMakerUtilities {
@@ -82,7 +82,7 @@ public class ChartListMakerUtilities {
 		log.debug("Making the moving average...");
 		for(int dayIndex = startDayIndex; dayIndex < endDayIndex; dayIndex++) {
 			movingAverage = 0;
-			for(int d = dayIndex; d > dayIndex - ChartListConstants.MOVING_AVERAGE_SIZE.getValue(); d--) {
+			for(int d = dayIndex; d > dayIndex - DataTransformConstants.MOVING_AVERAGE_SIZE.getValue(); d--) {
 				amountToAdd = dataMap.get(d);
 				if(Double.isNaN(amountToAdd) || Double.isInfinite(amountToAdd) || (int)amountToAdd == 100) {
 					log.trace("Oops...amountToAdd is not a real number, it is " + amountToAdd + ", so it will NOT be in the moving average.");

--- a/src/main/java/com/royware/corona/dashboard/services/chart/list/makers/CurrentTotalDeathsWithPercentOfPopulationChartList.java
+++ b/src/main/java/com/royware/corona/dashboard/services/chart/list/makers/CurrentTotalDeathsWithPercentOfPopulationChartList.java
@@ -11,7 +11,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
-import com.royware.corona.dashboard.enums.data.ChartListConstants;
+import com.royware.corona.dashboard.enums.data.DataTransformConstants;
 import com.royware.corona.dashboard.interfaces.chartlist.IChartListMaker;
 import com.royware.corona.dashboard.interfaces.model.ICanonicalCaseDeathData;
 
@@ -47,7 +47,7 @@ public class CurrentTotalDeathsWithPercentOfPopulationChartList implements IChar
 			dailyChange = totalToday - totalYesterday;
 			dailyChange = dailyChange > 0 ? dailyChange : 0;
 
-			if(dayIndex < startDayIndex + ChartListConstants.CURRENT_DEATHS_QUEUE_SIZE_PRIMARY.getValue()) {
+			if(dayIndex < startDayIndex + DataTransformConstants.CURRENT_DEATHS_QUEUE_SIZE_PRIMARY.getValue()) {
 				rollingSumPrimary = totalToday;
 			} else {
 				rollingSumPrimary += dailyChange - dailyChangeInDeathsPrimary.peek();
@@ -55,7 +55,7 @@ public class CurrentTotalDeathsWithPercentOfPopulationChartList implements IChar
 			}
 			dailyChangeInDeathsPrimary.add(dailyChange);
 			
-			if(dayIndex < startDayIndex + ChartListConstants.CURRENT_DEATHS_QUEUE_SIZE_SECONDARY.getValue()) {
+			if(dayIndex < startDayIndex + DataTransformConstants.CURRENT_DEATHS_QUEUE_SIZE_SECONDARY.getValue()) {
 				rollingSumSecondary = totalToday;
 			} else {
 				rollingSumSecondary += dailyChange - dailyChangeInDeathsSecondary.peek();
@@ -65,13 +65,13 @@ public class CurrentTotalDeathsWithPercentOfPopulationChartList implements IChar
 			
 			xyPair = new HashMap<>();
 			xyPair.put("x", dayIndex);
-			xyPair.put("y", rollingSumPrimary * ChartListConstants.PER_CAPITA_BASIS.getValue() * 1.0 / regionPopulation);
+			xyPair.put("y", rollingSumPrimary * DataTransformConstants.PER_CAPITA_BASIS.getValue() * 1.0 / regionPopulation);
 			xyPair.put("dateChecked", regionDataList.get(dayIndex).getDateChecked().toString());
 			dataListPrimary.add(xyPair);
 			
 			xyPairSec = new HashMap<>();
 			xyPairSec.put("x", dayIndex);
-			xyPairSec.put("y", rollingSumSecondary * ChartListConstants.PER_CAPITA_BASIS.getValue() * 1.0 / regionPopulation);
+			xyPairSec.put("y", rollingSumSecondary * DataTransformConstants.PER_CAPITA_BASIS.getValue() * 1.0 / regionPopulation);
 			dataListSecondary.add(xyPairSec);
 			dayIndex++;
 		}

--- a/src/main/java/com/royware/corona/dashboard/services/chart/list/makers/CurrentTotalPositivesWithPercentOfPopulationChartList.java
+++ b/src/main/java/com/royware/corona/dashboard/services/chart/list/makers/CurrentTotalPositivesWithPercentOfPopulationChartList.java
@@ -11,7 +11,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
-import com.royware.corona.dashboard.enums.data.ChartListConstants;
+import com.royware.corona.dashboard.enums.data.DataTransformConstants;
 import com.royware.corona.dashboard.interfaces.chartlist.IChartListMaker;
 import com.royware.corona.dashboard.interfaces.model.ICanonicalCaseDeathData;
 
@@ -46,7 +46,7 @@ public class CurrentTotalPositivesWithPercentOfPopulationChartList implements IC
 			dailyChange = totalToday - totalYesterday;
 			dailyChange = dailyChange > 0 ? dailyChange : 0;
 
-			if(dayIndex < ChartListConstants.CURRENT_POSITIVES_QUEUE_SIZE_PRIMARY.getValue()) {
+			if(dayIndex < DataTransformConstants.CURRENT_POSITIVES_QUEUE_SIZE_PRIMARY.getValue()) {
 				rollingSumPrimary = totalToday;
 			} else {
 				rollingSumPrimary += dailyChange - dailyChangeInPositivesPrimary.peek();
@@ -54,7 +54,7 @@ public class CurrentTotalPositivesWithPercentOfPopulationChartList implements IC
 			}
 			dailyChangeInPositivesPrimary.add(dailyChange);
 			
-			if(dayIndex < ChartListConstants.CURRENT_POSITIVES_QUEUE_SIZE_SECONDARY.getValue()) {
+			if(dayIndex < DataTransformConstants.CURRENT_POSITIVES_QUEUE_SIZE_SECONDARY.getValue()) {
 				rollingSumSecondary = totalToday;
 			} else {
 				rollingSumSecondary += dailyChange - dailyChangeInPositivesSecondary.peek();
@@ -64,13 +64,13 @@ public class CurrentTotalPositivesWithPercentOfPopulationChartList implements IC
 			
 			xyPair = new HashMap<>();
 			xyPair.put("x", dayIndex);
-			xyPair.put("y", rollingSumPrimary * ChartListConstants.PER_CAPITA_BASIS.getValue() * 1.0 / regionPopulation);
+			xyPair.put("y", rollingSumPrimary * DataTransformConstants.PER_CAPITA_BASIS.getValue() * 1.0 / regionPopulation);
 			xyPair.put("dateChecked", regionDataList.get(dayIndex).getDateChecked().toString());
 			dataListPrimary.add(xyPair);
 			
 			xyPairSec = new HashMap<>();
 			xyPairSec.put("x", dayIndex);
-			xyPairSec.put("y", rollingSumSecondary * ChartListConstants.PER_CAPITA_BASIS.getValue() * 1.0 / regionPopulation);
+			xyPairSec.put("y", rollingSumSecondary * DataTransformConstants.PER_CAPITA_BASIS.getValue() * 1.0 / regionPopulation);
 			dataListSecondary.add(xyPairSec);
 			dayIndex++;
 		}

--- a/src/main/java/com/royware/corona/dashboard/services/chart/list/makers/DailyAccelerationOfCasesWithMovingAverageChartList.java
+++ b/src/main/java/com/royware/corona/dashboard/services/chart/list/makers/DailyAccelerationOfCasesWithMovingAverageChartList.java
@@ -9,7 +9,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
-import com.royware.corona.dashboard.enums.data.ChartListConstants;
+import com.royware.corona.dashboard.enums.data.DataTransformConstants;
 import com.royware.corona.dashboard.interfaces.chartlist.IChartListMaker;
 import com.royware.corona.dashboard.interfaces.model.ICanonicalCaseDeathData;
 
@@ -51,7 +51,7 @@ public class DailyAccelerationOfCasesWithMovingAverageChartList implements IChar
 		scatterChartDataLists.add(
 			ChartListMakerUtilities.makeMovingAverageList(
 					dailyAccelCases,
-					ChartListConstants.MOVING_AVERAGE_SIZE.getValue() + 1,
+					DataTransformConstants.MOVING_AVERAGE_SIZE.getValue() + 1,
 					regionDataList.size()
 			));
 

--- a/src/main/java/com/royware/corona/dashboard/services/chart/list/makers/DailyAccelerationOfDeathsWithMovingAverageChartList.java
+++ b/src/main/java/com/royware/corona/dashboard/services/chart/list/makers/DailyAccelerationOfDeathsWithMovingAverageChartList.java
@@ -9,7 +9,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
-import com.royware.corona.dashboard.enums.data.ChartListConstants;
+import com.royware.corona.dashboard.enums.data.DataTransformConstants;
 import com.royware.corona.dashboard.interfaces.chartlist.IChartListMaker;
 import com.royware.corona.dashboard.interfaces.model.ICanonicalCaseDeathData;
 
@@ -54,7 +54,7 @@ public class DailyAccelerationOfDeathsWithMovingAverageChartList implements ICha
 		scatterChartDataLists.add(
 				ChartListMakerUtilities.makeMovingAverageList(
 					dailyAccelDeaths,
-					startDayIndex + ChartListConstants.MOVING_AVERAGE_SIZE.getValue() + 1,
+					startDayIndex + DataTransformConstants.MOVING_AVERAGE_SIZE.getValue() + 1,
 					regionDataList.size()
 				));
 

--- a/src/main/java/com/royware/corona/dashboard/services/chart/list/makers/DailyAndTotalCasesVersusTimeChartList.java
+++ b/src/main/java/com/royware/corona/dashboard/services/chart/list/makers/DailyAndTotalCasesVersusTimeChartList.java
@@ -9,7 +9,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
-import com.royware.corona.dashboard.enums.data.ChartListConstants;
+import com.royware.corona.dashboard.enums.data.DataTransformConstants;
 import com.royware.corona.dashboard.interfaces.chartlist.IChartListMaker;
 import com.royware.corona.dashboard.interfaces.model.ICanonicalCaseDeathData;
 
@@ -58,7 +58,7 @@ public class DailyAndTotalCasesVersusTimeChartList implements IChartListMaker {
 		scatterChartDataLists.add(
 			ChartListMakerUtilities.makeMovingAverageList(
 					dailyNewCases,
-					ChartListConstants.MOVING_AVERAGE_SIZE.getValue(),
+					DataTransformConstants.MOVING_AVERAGE_SIZE.getValue(),
 					regionDataList.size()
 			));
 		

--- a/src/main/java/com/royware/corona/dashboard/services/chart/list/makers/DailyHospitalizedNowWithMovingAverageChartList.java
+++ b/src/main/java/com/royware/corona/dashboard/services/chart/list/makers/DailyHospitalizedNowWithMovingAverageChartList.java
@@ -9,7 +9,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
-import com.royware.corona.dashboard.enums.data.ChartListConstants;
+import com.royware.corona.dashboard.enums.data.DataTransformConstants;
 import com.royware.corona.dashboard.interfaces.chartlist.IChartListMaker;
 import com.royware.corona.dashboard.interfaces.model.ICanonicalCaseDeathData;
 
@@ -63,7 +63,7 @@ public class DailyHospitalizedNowWithMovingAverageChartList implements IChartLis
 		scatterChartDataLists.add(
 				ChartListMakerUtilities.makeMovingAverageList(
 					dailyHospitalizations,
-					startDayIndex + ChartListConstants.MOVING_AVERAGE_SIZE.getValue(),
+					startDayIndex + DataTransformConstants.MOVING_AVERAGE_SIZE.getValue(),
 					regionDataList.size()
 				));
 		

--- a/src/main/java/com/royware/corona/dashboard/services/chart/list/makers/DailyHospitalizedTotalWithMovingAverageChartList.java
+++ b/src/main/java/com/royware/corona/dashboard/services/chart/list/makers/DailyHospitalizedTotalWithMovingAverageChartList.java
@@ -9,7 +9,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
-import com.royware.corona.dashboard.enums.data.ChartListConstants;
+import com.royware.corona.dashboard.enums.data.DataTransformConstants;
 import com.royware.corona.dashboard.interfaces.chartlist.IChartListMaker;
 import com.royware.corona.dashboard.interfaces.model.ICanonicalCaseDeathData;
 
@@ -59,7 +59,7 @@ public class DailyHospitalizedTotalWithMovingAverageChartList implements IChartL
 		log.debug("Making moving average of DAILY NEW hospitalizations");
 		scatterChartDataLists.add(
 				ChartListMakerUtilities.makeMovingAverageList(
-					cumulHospitalizations, startDayIndex + ChartListConstants.MOVING_AVERAGE_SIZE.getValue(),
+					cumulHospitalizations, startDayIndex + DataTransformConstants.MOVING_AVERAGE_SIZE.getValue(),
 					regionDataList.size()
 				));
 		

--- a/src/main/java/com/royware/corona/dashboard/services/chart/list/makers/DailyRateOfChangeOfCasesWithMovingAverageChartList.java
+++ b/src/main/java/com/royware/corona/dashboard/services/chart/list/makers/DailyRateOfChangeOfCasesWithMovingAverageChartList.java
@@ -9,7 +9,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
-import com.royware.corona.dashboard.enums.data.ChartListConstants;
+import com.royware.corona.dashboard.enums.data.DataTransformConstants;
 import com.royware.corona.dashboard.interfaces.chartlist.IChartListMaker;
 import com.royware.corona.dashboard.interfaces.model.ICanonicalCaseDeathData;
 
@@ -50,7 +50,7 @@ public class DailyRateOfChangeOfCasesWithMovingAverageChartList implements IChar
 		scatterChartDataLists.add(
 			ChartListMakerUtilities.makeMovingAverageList(
 					dailyPctChgCases,
-					ChartListConstants.MOVING_AVERAGE_SIZE.getValue(),
+					DataTransformConstants.MOVING_AVERAGE_SIZE.getValue(),
 					regionDataList.size()
 			));
 

--- a/src/main/java/com/royware/corona/dashboard/services/chart/list/makers/DailyRateOfChangeOfDeathsWithMovingAverageChartList.java
+++ b/src/main/java/com/royware/corona/dashboard/services/chart/list/makers/DailyRateOfChangeOfDeathsWithMovingAverageChartList.java
@@ -10,7 +10,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
-import com.royware.corona.dashboard.enums.data.ChartListConstants;
+import com.royware.corona.dashboard.enums.data.DataTransformConstants;
 import com.royware.corona.dashboard.interfaces.chartlist.IChartListMaker;
 import com.royware.corona.dashboard.interfaces.model.ICanonicalCaseDeathData;
 
@@ -55,7 +55,7 @@ public class DailyRateOfChangeOfDeathsWithMovingAverageChartList implements ICha
 		scatterChartDataLists.add(
 				ChartListMakerUtilities.makeMovingAverageList(
 					dailyPctChgDeaths,
-					startDayIndex + ChartListConstants.MOVING_AVERAGE_SIZE.getValue(),
+					startDayIndex + DataTransformConstants.MOVING_AVERAGE_SIZE.getValue(),
 					regionDataList.size()
 				));
 

--- a/src/main/java/com/royware/corona/dashboard/services/chart/list/makers/DailyRatioCasesToTestsWithMovingAverageChartList.java
+++ b/src/main/java/com/royware/corona/dashboard/services/chart/list/makers/DailyRatioCasesToTestsWithMovingAverageChartList.java
@@ -9,7 +9,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
-import com.royware.corona.dashboard.enums.data.ChartListConstants;
+import com.royware.corona.dashboard.enums.data.DataTransformConstants;
 import com.royware.corona.dashboard.interfaces.chartlist.IChartListMaker;
 import com.royware.corona.dashboard.interfaces.model.ICanonicalCaseDeathData;
 
@@ -64,7 +64,7 @@ public class DailyRatioCasesToTestsWithMovingAverageChartList implements IChartL
 		scatterChartDataLists.add(
 				ChartListMakerUtilities.makeMovingAverageList(
 					dailyRatioOfTests,
-					ChartListConstants.MOVING_AVERAGE_SIZE.getValue(),
+					DataTransformConstants.MOVING_AVERAGE_SIZE.getValue(),
 					regionDataList.size()
 				));
 

--- a/src/main/java/com/royware/corona/dashboard/services/chart/list/makers/DailyTestsTotalTestsVersusTimeChartList.java
+++ b/src/main/java/com/royware/corona/dashboard/services/chart/list/makers/DailyTestsTotalTestsVersusTimeChartList.java
@@ -9,7 +9,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
-import com.royware.corona.dashboard.enums.data.ChartListConstants;
+import com.royware.corona.dashboard.enums.data.DataTransformConstants;
 import com.royware.corona.dashboard.interfaces.chartlist.IChartListMaker;
 import com.royware.corona.dashboard.interfaces.model.ICanonicalCaseDeathData;
 
@@ -57,7 +57,7 @@ public class DailyTestsTotalTestsVersusTimeChartList implements IChartListMaker 
 		scatterChartDataLists.add(
 			ChartListMakerUtilities.makeMovingAverageList(
 				dailyTests,
-				ChartListConstants.MOVING_AVERAGE_SIZE.getValue(),
+				DataTransformConstants.MOVING_AVERAGE_SIZE.getValue(),
 				regionDataList.size()
 			));
 		

--- a/src/main/java/com/royware/corona/dashboard/services/chart/list/makers/DailyVaccTotalVaccVersusTimeChartList.java
+++ b/src/main/java/com/royware/corona/dashboard/services/chart/list/makers/DailyVaccTotalVaccVersusTimeChartList.java
@@ -9,7 +9,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
-import com.royware.corona.dashboard.enums.data.ChartListConstants;
+import com.royware.corona.dashboard.enums.data.DataTransformConstants;
 import com.royware.corona.dashboard.interfaces.chartlist.IChartListMaker;
 import com.royware.corona.dashboard.interfaces.model.ICanonicalCaseDeathData;
 
@@ -57,7 +57,7 @@ public class DailyVaccTotalVaccVersusTimeChartList implements IChartListMaker {
 		scatterChartDataLists.add(
 				ChartListMakerUtilities.makeMovingAverageList(
 					dailyVacc,
-					ChartListConstants.MOVING_AVERAGE_SIZE.getValue(),
+					DataTransformConstants.MOVING_AVERAGE_SIZE.getValue(),
 					regionDataList.size()
 				));
 		

--- a/src/main/java/com/royware/corona/dashboard/services/chart/list/makers/TotalDeathsVersusTimeWithExponentialFitChartList.java
+++ b/src/main/java/com/royware/corona/dashboard/services/chart/list/makers/TotalDeathsVersusTimeWithExponentialFitChartList.java
@@ -9,7 +9,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
-import com.royware.corona.dashboard.enums.data.ChartListConstants;
+import com.royware.corona.dashboard.enums.data.DataTransformConstants;
 import com.royware.corona.dashboard.interfaces.chartlist.IChartListMaker;
 import com.royware.corona.dashboard.interfaces.model.ICanonicalCaseDeathData;
 
@@ -62,7 +62,7 @@ public class TotalDeathsVersusTimeWithExponentialFitChartList implements IChartL
 		scatterChartDataLists.add(
 			ChartListMakerUtilities.makeMovingAverageList(
 				dailyDeaths,
-				startDayIndex + ChartListConstants.MOVING_AVERAGE_SIZE.getValue(),
+				startDayIndex + DataTransformConstants.MOVING_AVERAGE_SIZE.getValue(),
 				regionDataList.size()
 			));
 		

--- a/src/main/java/com/royware/corona/dashboard/services/dashboard/DashboardConfigServiceImpl.java
+++ b/src/main/java/com/royware/corona/dashboard/services/dashboard/DashboardConfigServiceImpl.java
@@ -11,7 +11,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.ui.ModelMap;
 
 import com.royware.corona.dashboard.enums.dashstats.DashStatsTypes;
-import com.royware.corona.dashboard.enums.data.ChartListConstants;
+import com.royware.corona.dashboard.enums.data.DataTransformConstants;
 import com.royware.corona.dashboard.enums.regions.RegionsInDashboard;
 import com.royware.corona.dashboard.interfaces.dashboard.IDashboardChartService;
 import com.royware.corona.dashboard.interfaces.dashboard.IDashboardConfigService;
@@ -113,7 +113,7 @@ public class DashboardConfigServiceImpl implements IDashboardConfigService {
 				DashStatsTypes.DASHSTATS_PER_CAPITA_STATS, dashStats, null, null, regionPopulation);
 		
 		//////// SET ALL DASHBOARD META DATA AND HEADER DATA ////////
-		dashMeta.setPerCapitaBasis(ChartListConstants.PER_CAPITA_BASIS.getValue());
+		dashMeta.setPerCapitaBasis(DataTransformConstants.PER_CAPITA_BASIS.getValue());
 		dashHeader.setFullRegion(fullRegionString);
 		if(fullRegionString.length() > MAX_REGION_LENGTH_TO_DISPLAY) {
 			dashHeader.setFullRegion(fullRegionString.substring(0, MAX_REGION_LENGTH_TO_DISPLAY + 1) + "...");

--- a/src/main/java/com/royware/corona/dashboard/services/dashstats/makers/DashStatsForRegionDeathsMovingSumMaker.java
+++ b/src/main/java/com/royware/corona/dashboard/services/dashstats/makers/DashStatsForRegionDeathsMovingSumMaker.java
@@ -3,7 +3,7 @@ package com.royware.corona.dashboard.services.dashstats.makers;
 import java.util.List;
 import java.util.Map;
 
-import com.royware.corona.dashboard.enums.data.ChartListConstants;
+import com.royware.corona.dashboard.enums.data.DataTransformConstants;
 import com.royware.corona.dashboard.interfaces.dashboard.IDashStatsMaker;
 import com.royware.corona.dashboard.interfaces.model.ICanonicalCaseDeathData;
 import com.royware.corona.dashboard.model.dashboard.DashboardStatistics;
@@ -21,12 +21,12 @@ public class DashStatsForRegionDeathsMovingSumMaker implements IDashStatsMaker {
 		
 		List<Map<Object, Object>> chartDataList = (List<Map<Object, Object>>) chartData.get(0);
 		dashStats.setDeathsMovingSumPrimary(
-				(double) ChartConfigMakerUtilities.computeTotalQuantityLastN(chartDataList, ChartListConstants.CURRENT_POSITIVES_QUEUE_SIZE_PRIMARY.getValue())
-				* 1.0 * ChartListConstants.PER_CAPITA_BASIS.getValue()
+				(double) ChartConfigMakerUtilities.computeTotalQuantityLastN(chartDataList, DataTransformConstants.CURRENT_POSITIVES_QUEUE_SIZE_PRIMARY.getValue())
+				* 1.0 * DataTransformConstants.PER_CAPITA_BASIS.getValue()
 				/ regionPop);
 		dashStats.setDeathsMovingSumSecondary(
-				(double) ChartConfigMakerUtilities.computeTotalQuantityLastN(chartDataList, ChartListConstants.CURRENT_POSITIVES_QUEUE_SIZE_SECONDARY.getValue())
-				* 1.0 * ChartListConstants.PER_CAPITA_BASIS.getValue()
+				(double) ChartConfigMakerUtilities.computeTotalQuantityLastN(chartDataList, DataTransformConstants.CURRENT_POSITIVES_QUEUE_SIZE_SECONDARY.getValue())
+				* 1.0 * DataTransformConstants.PER_CAPITA_BASIS.getValue()
 				/ regionPop);
 		
 		return dashStats;

--- a/src/main/java/com/royware/corona/dashboard/services/dashstats/makers/DashStatsForRegionVaccMaker.java
+++ b/src/main/java/com/royware/corona/dashboard/services/dashstats/makers/DashStatsForRegionVaccMaker.java
@@ -3,7 +3,7 @@ package com.royware.corona.dashboard.services.dashstats.makers;
 import java.util.List;
 import java.util.Map;
 
-import com.royware.corona.dashboard.enums.data.ChartListConstants;
+import com.royware.corona.dashboard.enums.data.DataTransformConstants;
 import com.royware.corona.dashboard.interfaces.dashboard.IDashStatsMaker;
 import com.royware.corona.dashboard.interfaces.model.ICanonicalCaseDeathData;
 import com.royware.corona.dashboard.model.dashboard.DashboardStatistics;
@@ -24,12 +24,12 @@ public class DashStatsForRegionVaccMaker implements IDashStatsMaker {
 		dashStats.setVaccToday((int) chartData.get(0).get(chartData.get(0).size() - 1).get("y")
 				- (int) chartData.get(0).get(chartData.get(0).size() - 2).get("y"));
 		dashStats.setVaccMovingSumPrimary(
-				(double) ChartConfigMakerUtilities.computeTotalQuantityLastN(chartDataList, ChartListConstants.CURRENT_POSITIVES_QUEUE_SIZE_PRIMARY.getValue())
-				* 1.0 * ChartListConstants.PER_CAPITA_BASIS.getValue()
+				(double) ChartConfigMakerUtilities.computeTotalQuantityLastN(chartDataList, DataTransformConstants.CURRENT_POSITIVES_QUEUE_SIZE_PRIMARY.getValue())
+				* 1.0 * DataTransformConstants.PER_CAPITA_BASIS.getValue()
 				/ regionPop);
 		dashStats.setVaccMovingSumSecondary(
-				(double) ChartConfigMakerUtilities.computeTotalQuantityLastN(chartDataList, ChartListConstants.CURRENT_POSITIVES_QUEUE_SIZE_SECONDARY.getValue())
-				* 1.0 * ChartListConstants.PER_CAPITA_BASIS.getValue()
+				(double) ChartConfigMakerUtilities.computeTotalQuantityLastN(chartDataList, DataTransformConstants.CURRENT_POSITIVES_QUEUE_SIZE_SECONDARY.getValue())
+				* 1.0 * DataTransformConstants.PER_CAPITA_BASIS.getValue()
 				/ regionPop);
 		
 		return dashStats;

--- a/src/main/java/com/royware/corona/dashboard/services/dashstats/makers/DashStatsForUSRegionsByTestingMaker.java
+++ b/src/main/java/com/royware/corona/dashboard/services/dashstats/makers/DashStatsForUSRegionsByTestingMaker.java
@@ -6,7 +6,7 @@ import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.royware.corona.dashboard.enums.data.ChartListConstants;
+import com.royware.corona.dashboard.enums.data.DataTransformConstants;
 import com.royware.corona.dashboard.enums.regions.RegionsInDashboard;
 import com.royware.corona.dashboard.interfaces.dashboard.IDashStatsMaker;
 import com.royware.corona.dashboard.interfaces.model.ICanonicalCaseDeathData;
@@ -32,10 +32,10 @@ public class DashStatsForUSRegionsByTestingMaker implements IDashStatsMaker {
 		log.debug("Making ProportionOfPositiveTests and ProportionOfPositiveTestsMovingAverage");
 		dashStats.setProportionOfPositiveTests(dataList.get(dataList.size() - 1).getTotalPositiveCases()
 				* 100.0 / dashStats.getTotalTestsConducted());
-		int totalTestsLastN = ChartConfigMakerUtilities.computeTotalQuantityLastN(chartData.get(0), ChartListConstants.CURRENT_POSITIVES_QUEUE_SIZE_PRIMARY.getValue());
+		int totalTestsLastN = ChartConfigMakerUtilities.computeTotalQuantityLastN(chartData.get(0), DataTransformConstants.CURRENT_POSITIVES_QUEUE_SIZE_PRIMARY.getValue());
 		dashStats.setTotalTestsConductedLastN(totalTestsLastN);
 		dashStats.setProportionOfPositiveTestsMovingAverage(
-				ChartConfigMakerUtilities.computeTotalQuantityLastN(chartData.get(0), ChartListConstants.CURRENT_POSITIVES_QUEUE_SIZE_PRIMARY.getValue())* 100.0 / totalTestsLastN);
+				ChartConfigMakerUtilities.computeTotalQuantityLastN(chartData.get(0), DataTransformConstants.CURRENT_POSITIVES_QUEUE_SIZE_PRIMARY.getValue())* 100.0 / totalTestsLastN);
 		log.debug("Making ProportionOfPopulationTested");
 		dashStats.setProportionOfPopulationTested(dashStats.getTotalTestsConducted()
 				* 100.0 / usaPop);

--- a/src/main/java/com/royware/corona/dashboard/services/dashstats/makers/DashStatsPerCapitaStatsMaker.java
+++ b/src/main/java/com/royware/corona/dashboard/services/dashstats/makers/DashStatsPerCapitaStatsMaker.java
@@ -3,7 +3,7 @@ package com.royware.corona.dashboard.services.dashstats.makers;
 import java.util.List;
 import java.util.Map;
 
-import com.royware.corona.dashboard.enums.data.ChartListConstants;
+import com.royware.corona.dashboard.enums.data.DataTransformConstants;
 import com.royware.corona.dashboard.interfaces.dashboard.IDashStatsMaker;
 import com.royware.corona.dashboard.interfaces.model.ICanonicalCaseDeathData;
 import com.royware.corona.dashboard.model.dashboard.DashboardStatistics;
@@ -18,11 +18,11 @@ public class DashStatsPerCapitaStatsMaker implements IDashStatsMaker {
 			dashStats = new DashboardStatistics();
 		}
 		
-		dashStats.setCasesPerCapita(dashStats.getCasesTotal() * 1.0 * ChartListConstants.PER_CAPITA_BASIS.getValue() / regionPop);
+		dashStats.setCasesPerCapita(dashStats.getCasesTotal() * 1.0 * DataTransformConstants.PER_CAPITA_BASIS.getValue() / regionPop);
 		dashStats.setCasesPercentOfPop(dashStats.getCasesTotal() * 100.0 / regionPop);
-		dashStats.setDeathsPerCapita(dashStats.getDeathsTotal() * 1.0 * ChartListConstants.PER_CAPITA_BASIS.getValue() / regionPop);
+		dashStats.setDeathsPerCapita(dashStats.getDeathsTotal() * 1.0 * DataTransformConstants.PER_CAPITA_BASIS.getValue() / regionPop);
 		dashStats.setDeathsPercentOfPop(dashStats.getDeathsTotal() * 100.0 / regionPop);
-		dashStats.setVaccPerCapita(dashStats.getTotalVaccCompleted() * 1.0 * ChartListConstants.PER_CAPITA_BASIS.getValue() / regionPop);
+		dashStats.setVaccPerCapita(dashStats.getTotalVaccCompleted() * 1.0 * DataTransformConstants.PER_CAPITA_BASIS.getValue() / regionPop);
 		dashStats.setVaccPercentOfPop(dashStats.getTotalVaccCompleted() * 100.0 / regionPop);
 		
 		return dashStats;

--- a/src/main/java/com/royware/corona/dashboard/services/data/source/connection/factory/ExternalDataListGetterFactory.java
+++ b/src/main/java/com/royware/corona/dashboard/services/data/source/connection/factory/ExternalDataListGetterFactory.java
@@ -28,9 +28,9 @@ public class ExternalDataListGetterFactory implements IExternalDataListGetterFac
 	@Qualifier(value = "usExcludingState")
 	private IExternalDataListGetter usExcludingStateDataListGetter;
 	
-	/*@Autowired
+	@Autowired
 	@Qualifier(value = "singleCountry")
-	private IExternalDataListGetter singleCountryDataSource;*/
+	private IExternalDataListGetter singleCountryDataSource;
 	
 	private static final Logger log = LoggerFactory.getLogger(ExternalDataListGetterFactory.class);
 	
@@ -46,9 +46,9 @@ public class ExternalDataListGetterFactory implements IExternalDataListGetterFac
 			dataService = usExcludingStateDataListGetter;
 		} else if(regionOfService.length() == 2) {
 			dataService = singleStateDataListGetter;
-		} /*else if(regionOfService.length() == 3){
+		} else if(regionOfService.length() == 3){
 			dataService = singleCountryDataSource;
-		}*/ else if(regionOfService.substring(0,5).equalsIgnoreCase("MULTI")) {
+		} else if(regionOfService.substring(0,5).equalsIgnoreCase("MULTI")) {
 			dataService = multiStateDataListGetter;
 		} else {
 			log.error("getExternalDataService NO MATCHES to regionOfService: '" + regionOfService + "'. Throwing exception!!!");

--- a/src/main/java/com/royware/corona/dashboard/services/data/source/connections/us/ExternalDataListGetterSingleState.java
+++ b/src/main/java/com/royware/corona/dashboard/services/data/source/connections/us/ExternalDataListGetterSingleState.java
@@ -13,6 +13,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 
+import com.royware.corona.dashboard.enums.data.DataTransformConstants;
 import com.royware.corona.dashboard.enums.data.DataUrls;
 import com.royware.corona.dashboard.interfaces.data.IExternalDataListGetter;
 import com.royware.corona.dashboard.model.data.us.CaseDeathVaccData_CovidActNow;
@@ -86,7 +87,7 @@ public class ExternalDataListGetterSingleState implements IExternalDataListGette
 		List<UnitedStatesData> stateDataList = buildUnitedStatesDataList(stateAbbreviation, hospitalizationDataArray, caseDeathVaccArray);
 		log.debug("The size of the pre-filtered state data list for " + stateAbbreviation + " is: " + stateDataList.size());
 		
-		stateDataList.removeIf(unitedStatesCase -> (unitedStatesCase.getDateInteger() < US_CUTOFF_DATE));
+		stateDataList.removeIf(unitedStatesCase -> (unitedStatesCase.getDateInteger() < DataTransformConstants.US_CUTOFF_DATE.getValue()));
 		
 		log.debug("FINISHED GETTING DATA FOR STATE: " + stateAbbreviation);
 		


### PR DESCRIPTION
* The ExternalDataListGetterWorld was broken. It was not filtering the
entire world data list by the country selected. Added the filter back in
from the old ExternalDataServiceSingleCountryImpl class that was deleted
as part of the refactoring of external data list getters
(https://github.com/roychancellor/coronavirustracker/pull/38/files).
* The ExternalDataListGetterFactory was also broken, as it was not
assigning an object to cases where the region string was not USA but was
3 characters (the indicator of a non-USA country). Added the case back
in.
* Changed the name of ChartListConstants to DataTransformConstants and
added the threshold for adding a cases value to a list as an enum.
* Removed the US_CUTOFF_DATE constant from the IExternalDataListGetter
interface and put it as an enum in DataTransformConstants.